### PR TITLE
Add pre-commit.ci instead of action/pre-commit

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,8 +13,6 @@ jobs:
         with:
           python-version: 3.8
 
-      - uses: pre-commit/action@v2.0.3
-
       - name: Install dependencies
         run: |
             python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,7 @@ repos:
     hooks:
       - id: isort
         name: Check isort
+
+# See https://pre-commit.ci/ for more information
+ci:
+  autoupdate_schedule: weekly


### PR DESCRIPTION
The pre-commit action is in mainteance mode
(https://github.com/pre-commit/action), they are suggesting to use
pre-commit.ci