### PR TITLE
Add handling of click.exceptions.Exit

### DIFF
--- a/unblob/cli.py
+++ b/unblob/cli.py
@@ -47,6 +47,8 @@ def main():
     except click.ClickException as e:
         e.show()
         sys.exit(e.exit_code)
+    except click.exceptions.Exit as e:
+        sys.exit(e.exit_code)
 
     with ctx:
         cli.invoke(ctx)


### PR DESCRIPTION
When adding own exception handling for the CLI in
b1bff2ee8e7e9529d7738bf44062bd412884d24c, we missed handling this
exception, which is handled now. This exception is currently used by
`click` to exit when using the `--help` option in the CLI.

Closes #30 