### PR TITLE
New StructHandler base class

### DIFF
--- a/unblob/handlers/archive/cab.py
+++ b/unblob/handlers/archive/cab.py
@@ -3,12 +3,12 @@ from typing import List, Union
 
 from structlog import get_logger
 
-from ...models import Handler, UnknownChunk, ValidChunk
+from ...models import StructHandler, UnknownChunk, ValidChunk
 
 logger = get_logger()
 
 
-class CABHandler(Handler):
+class CABHandler(StructHandler):
     NAME = "cab"
 
     YARA_RULE = r"""
@@ -18,7 +18,7 @@ class CABHandler(Handler):
             $magic
     """
 
-    C_STRUCTURES = r"""
+    C_DEFINITIONS = r"""
         struct cab_header
         {
             u1  signature[4];  /* cabinet file signature contains the characters 'M','S','C','F' (bytes 0x4D, 0x53, 0x43, 0x46). */

--- a/unblob/handlers/archive/cpio.py
+++ b/unblob/handlers/archive/cpio.py
@@ -4,7 +4,7 @@ from typing import List, Union
 from structlog import get_logger
 
 from ...file_utils import round_up, snull
-from ...models import Handler, UnknownChunk, ValidChunk
+from ...models import StructHandler, UnknownChunk, ValidChunk
 
 logger = get_logger()
 
@@ -12,7 +12,7 @@ CPIO_TRAILER_NAME = b"TRAILER!!!"
 MAX_LINUX_PATH_LENGTH = 0x1000
 
 
-class _CPIOHandlerBase(Handler):
+class _CPIOHandlerBase(StructHandler):
     """A common base for all CPIO formats
     The format should be parsed the same, there are small differences how to calculate
     file and filename sizes padding and conversion from octal / hex.
@@ -95,7 +95,7 @@ class BinaryHandler(_CPIOHandlerBase):
             $cpio_binary_magic
     """
 
-    C_STRUCTURES = r"""
+    C_DEFINITIONS = r"""
         struct old_cpio_header
         {
             ushort c_magic;
@@ -134,7 +134,7 @@ class PortableOldASCIIHandler(_CPIOHandlerBase):
         condition:
             $cpio_portable_old_ascii_magic
     """
-    C_STRUCTURES = r"""
+    C_DEFINITIONS = r"""
         struct old_ascii_header
         {
             char c_magic[6];
@@ -163,8 +163,8 @@ class PortableOldASCIIHandler(_CPIOHandlerBase):
         return int(header.c_namesize, 8)
 
 
-class _NewASCIICommon(Handler):
-    C_STRUCTURES = r"""
+class _NewASCIICommon(StructHandler):
+    C_DEFINITIONS = r"""
         struct new_ascii_header
         {
             char c_magic[6];

--- a/unblob/handlers/archive/tar.py
+++ b/unblob/handlers/archive/tar.py
@@ -5,7 +5,7 @@ from typing import List, Union
 from structlog import get_logger
 
 from ...file_utils import snull
-from ...models import Handler, UnknownChunk, ValidChunk
+from ...models import StructHandler, UnknownChunk, ValidChunk
 
 logger = get_logger()
 
@@ -34,7 +34,7 @@ def _get_tar_end_offset(file: io.BufferedIOBase):
     return end_offset
 
 
-class TarHandler(Handler):
+class TarHandler(StructHandler):
     NAME = "tar"
 
     YARA_RULE = r"""
@@ -49,7 +49,7 @@ class TarHandler(Handler):
     # to get to the start of the file.
     YARA_MATCH_OFFSET = -MAGIC_OFFSET
 
-    C_STRUCTURES = r"""
+    C_DEFINITIONS = r"""
         struct posix_header
         {                       /* byte offset */
             char name[100];     /*   0 */

--- a/unblob/handlers/filesystem/squashfs.py
+++ b/unblob/handlers/filesystem/squashfs.py
@@ -2,11 +2,10 @@ import io
 import struct
 from typing import List, Union
 
-from dissect.cstruct import cstruct
 from structlog import get_logger
 
-from ...file_utils import round_up
-from ...models import Handler, UnknownChunk, ValidChunk
+from ...file_utils import Endian, round_up
+from ...models import StructHandler, UnknownChunk, ValidChunk
 
 logger = get_logger()
 
@@ -14,7 +13,7 @@ PAD_SIZE = 4096
 BIG_ENDIAN_MAGIC = 0x73717368
 
 
-class _SquashFSBase(Handler):
+class _SquashFSBase(StructHandler):
     @staticmethod
     def make_extract_command(inpath: str, outdir: str) -> List[str]:
         return ["unsquashfs", "-f", "-d", outdir, inpath]
@@ -41,7 +40,7 @@ class SquashFSv3Handler(_SquashFSBase):
             $squashfs_v3_magic_le or $squashfs_v3_magic_be
     """
 
-    C_STRUCTURES = r"""
+    C_DEFINITIONS = r"""
         struct SQUASHFS3_SUPER_BLOCK
         {
             char   s_magic[4];
@@ -72,13 +71,7 @@ class SquashFSv3Handler(_SquashFSBase):
             int64  lookup_table_start;
         };
     """
-
-    def __init__(self):
-        self.cparser_le = cstruct()
-        self.cparser_le.load(self.C_STRUCTURES)
-
-        self.cparser_be = cstruct(endian=">")
-        self.cparser_be.load(self.C_STRUCTURES)
+    HEADER_STRUCT = "SQUASHFS3_SUPER_BLOCK"
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int
@@ -87,11 +80,10 @@ class SquashFSv3Handler(_SquashFSBase):
         # read the magic and derive endianness from it
         magic_bytes = file.read(4)
         magic = struct.unpack(">I", magic_bytes)[0]
-        cparser = self.cparser_be if magic == BIG_ENDIAN_MAGIC else self.cparser_le
+        endian = Endian.BIG if magic == BIG_ENDIAN_MAGIC else Endian.LITTLE
 
         file.seek(start_offset)
-        header = cparser.SQUASHFS3_SUPER_BLOCK(file)
-        logger.debug("Header parsed", header=header)
+        header = self.parse_header(file, endian)
 
         size = round_up(header.bytes_used, PAD_SIZE)
         end_offset = start_offset + size
@@ -114,7 +106,7 @@ class SquashFSv4Handler(_SquashFSBase):
             $squashfs_v4_magic_le
     """
 
-    C_STRUCTURES = r"""
+    C_DEFINITIONS = r"""
         struct SQUASHFS4_SUPER_BLOCK
         {
             char   s_magic[4];

--- a/unblob/handlers/filesystem/squashfs.py
+++ b/unblob/handlers/filesystem/squashfs.py
@@ -9,8 +9,8 @@ from ...models import StructHandler, UnknownChunk, ValidChunk
 
 logger = get_logger()
 
-PAD_SIZE = 4096
-BIG_ENDIAN_MAGIC = 0x73717368
+PAD_SIZE = 4_096
+BIG_ENDIAN_MAGIC = 0x73_71_73_68
 
 
 class _SquashFSBase(StructHandler):


### PR DESCRIPTION
We need to be able to parse structs with different endianness dynamically.
The StructParser class creates the cparser for the given endian lazily.

Handlers which want to use this parser must subclass StructHandler.