### PR TITLE
Add gitignore rule to discard __pycache__ generated content.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /*_extract/
+*__pycache__*


### PR DESCRIPTION
I think it'll make things easier I guess. I tend to have a list of unstaged changes for __pycache__ directories.