### PR TITLE
Add support for bzip2 compression format.

### DIFF
--- a/tests/handlers/compression/test_bzip2.py
+++ b/tests/handlers/compression/test_bzip2.py
@@ -17,6 +17,7 @@ def shift_left(value: bytes, bits: int) -> bytes:
 @pytest.mark.parametrize(
     "content, start_offset, expected_end_offset",
     (
+        pytest.param(b"123", 0, -1, id="shorter_than_block"),
         pytest.param(b"asdfasdf", 0, -1, id="not_found"),
         pytest.param(BLOCK_HEADER + b"123" + BLOCK_ENDMARK, 0, 9, id="aligned_to_zero"),
         pytest.param(

--- a/tests/handlers/compression/test_bzip2.py
+++ b/tests/handlers/compression/test_bzip2.py
@@ -1,0 +1,62 @@
+import io
+
+import pytest
+
+from unblob.handlers.compression.bzip2 import BZip2Handler
+
+BLOCK_HEADER = b"\x31\x41\x59\x26\x53\x59"
+BLOCK_ENDMARK = b"\x17\x72\x45\x38\x50\x90"
+
+
+def shift_left(value: bytes, bits: int) -> bytes:
+    # big endian to keep the order
+    left_shifted = int.from_bytes(value, byteorder="big") << bits
+    return left_shifted.to_bytes(7, byteorder="big")
+
+
+@pytest.mark.parametrize(
+    "content, start_offset, expected_end_offset",
+    (
+        pytest.param(b"asdfasdf", 0, -1, id="not_found"),
+        pytest.param(BLOCK_HEADER + b"123" + BLOCK_ENDMARK, 0, 9, id="aligned_to_zero"),
+        pytest.param(
+            b"0123" + BLOCK_HEADER + b"456" + BLOCK_ENDMARK,
+            4,
+            13,
+            id="aligned_with_offset",
+        ),
+        pytest.param(
+            b"0123" + BLOCK_HEADER + BLOCK_ENDMARK,
+            4,
+            10,
+            id="aligned_offset_empty_content",
+        ),
+        pytest.param(b"0123" + BLOCK_HEADER, 0, -1, id="no_block_endmark"),
+        pytest.param(b"0123" + BLOCK_ENDMARK, 0, -1, id="no_block_header"),
+        # extra byte when shifted
+        pytest.param(
+            shift_left(BLOCK_HEADER, 1) + b"123" + BLOCK_ENDMARK,
+            0,
+            10,
+            id="block_header_left_shifted",
+        ),
+        pytest.param(
+            BLOCK_HEADER + b"123" + shift_left(BLOCK_ENDMARK, 1),
+            0,
+            10,
+            id="block_endmark_left_shifted",
+        ),
+        pytest.param(
+            shift_left(BLOCK_HEADER, 1) + b"123" + shift_left(BLOCK_ENDMARK, 1),
+            0,
+            11,
+            id="both_marks_shifted",
+        ),
+        # undefined behavior: (BLOCK_ENDMARK + BLOCK_HEADER, 0, -1),
+    ),
+)
+def test_bzip2_recover(content: bytes, start_offset: int, expected_end_offset: int):
+    handler = BZip2Handler()
+    fake_file = io.BytesIO(content)
+    end_offset = handler.bzip2_recover(fake_file, start_offset)
+    assert end_offset == expected_end_offset

--- a/tests/integration/compression/bzip2/__input__/lorem.txt.bz2
+++ b/tests/integration/compression/bzip2/__input__/lorem.txt.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92cf0f3476c5cd45d112985624be66a543fbb92f46142cd579a778795f1cea03
+size 2545

--- a/tests/integration/compression/bzip2/__output__/lorem.txt.bz2_extract/0-2545.bzip2
+++ b/tests/integration/compression/bzip2/__output__/lorem.txt.bz2_extract/0-2545.bzip2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92cf0f3476c5cd45d112985624be66a543fbb92f46142cd579a778795f1cea03
+size 2545

--- a/tests/integration/compression/bzip2/__output__/lorem.txt.bz2_extract/0-2545.bzip2_extract/0-2545
+++ b/tests/integration/compression/bzip2/__output__/lorem.txt.bz2_extract/0-2545.bzip2_extract/0-2545
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6015681ff30441238676a933d6920ed2691e04b9d992ac2aaeab9a62bca9553
+size 6560

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -16,6 +16,19 @@ class Endian(enum.Enum):
     BIG = ">"
 
 
+def bits(file: io.BufferedIOBase) -> Iterator[int]:
+    """bit-wise reading of file in little-endian mode"""
+    try:
+        cur_bytes = file.read(8)
+        while cur_bytes:
+            for b in cur_bytes:
+                for i in range(7, -1, -1):
+                    yield (b >> i) & 1
+            cur_bytes = file.read(8)
+    except EOFError:
+        yield 2
+
+
 def snull(content: bytes):
     """Strip null bytes from the end of the string."""
     return content.rstrip(b"\x00")

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -10,6 +10,8 @@ from dissect.cstruct import cstruct
 
 from .logging import format_hex
 
+DEFAULT_BUFSIZE = shutil.COPY_BUFSIZE  # type: ignore
+
 
 class Endian(enum.Enum):
     LITTLE = "<"
@@ -85,7 +87,7 @@ def iterate_file(
     start_offset: int,
     size: int,
     # default buffer size in shutil for unix based systems
-    buffer_size: int = shutil.COPY_BUFSIZE,  # type: ignore
+    buffer_size: int = DEFAULT_BUFSIZE,
 ) -> Iterator[bytes]:
 
     if buffer_size <= 0:

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -18,17 +18,12 @@ class Endian(enum.Enum):
     BIG = ">"
 
 
-def bits(file: io.BufferedIOBase) -> Iterator[int]:
+def iterbits(file: io.BufferedIOBase) -> Iterator[int]:
     """bit-wise reading of file in little-endian mode"""
-    try:
-        cur_bytes = file.read(8)
-        while cur_bytes:
-            for b in cur_bytes:
-                for i in range(7, -1, -1):
-                    yield (b >> i) & 1
-            cur_bytes = file.read(8)
-    except EOFError:
-        yield 2
+    while cur_bytes := file.read(DEFAULT_BUFSIZE):
+        for b in cur_bytes:
+            for i in range(7, -1, -1):
+                yield (b >> i) & 1
 
 
 def snull(content: bytes):

--- a/unblob/handlers/__init__.py
+++ b/unblob/handlers/__init__.py
@@ -2,7 +2,7 @@ from typing import List, Tuple, Type
 
 from ..models import Handler
 from .archive import ar, arc, arj, cab, cpio, dmg, rar, sevenzip, tar, zip
-from .compression import lzo
+from .compression import bzip2, lzo
 from .filesystem import cramfs, fat, iso9660, squashfs, ubi
 
 ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
@@ -30,5 +30,8 @@ ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
         dmg.DMGHandler,
         iso9660.ISO9660FSHandler,
     ),
-    (lzo.LZOHandler,),
+    (
+        bzip2.BZip2Handler,
+        lzo.LZOHandler,
+    ),
 ]

--- a/unblob/handlers/compression/bzip2.py
+++ b/unblob/handlers/compression/bzip2.py
@@ -67,7 +67,6 @@ class BZip2Handler(StructHandler):
         buff = 0
         curr_block = 0
         blocks_found = 0
-        current_block_start = 0
         current_block_end = 0
 
         file.seek(start_offset)
@@ -79,20 +78,12 @@ class BZip2Handler(StructHandler):
 
             if buff == BLOCK_HEADER or buff == BLOCK_ENDMARK:
                 blocks_found += 1
-
-                if bits_read > COMPRESSED_MAGIC_LENGTH + 1:
-                    current_block_end = bits_read - (COMPRESSED_MAGIC_LENGTH + 1)
-
-                if curr_block > 0 and (current_block_end - current_block_start) >= 130:
-                    logger.debug(
-                        "bzip2_recover (complete block)",
-                        block_id=curr_block,
-                        block_start=current_block_start,
-                        block_end=current_block_end,
-                    )
+                # This can be negative, but we don't care, because we also count found blocks
+                # and in the case we didn't found both of them, we don't use this value
+                # When there are two blocks found, this will reflect the correct end
+                current_block_end = bits_read - (COMPRESSED_MAGIC_LENGTH + 1)
 
                 curr_block += 1
-                current_block_start = bits_read
 
         if blocks_found < 2:
             return -1

--- a/unblob/handlers/compression/bzip2.py
+++ b/unblob/handlers/compression/bzip2.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from structlog import get_logger
 
-from ...file_utils import Endian, bits, round_up
+from ...file_utils import Endian, iterbits, round_up
 from ...models import StructHandler, ValidChunk
 
 logger = get_logger()
@@ -66,23 +66,8 @@ class BZip2Handler(StructHandler):
 
         file.seek(start_offset)
 
-        for b in bits(file):
+        for b in iterbits(file):
             bits_read += 1
-            if b == 2:
-                if (bits_read >= current_block_start) and (
-                    bits_read - current_block_start >= 40
-                ):
-                    current_block_end = bits_read - 1
-                    if curr_block > 0:
-                        logger.debug(
-                            "bzip2_recover (incomplete block)",
-                            block_id=curr_block,
-                            block_start=current_block_start,
-                            block_end=current_block_end,
-                        )
-                else:
-                    curr_block -= 1
-                break
 
             buff_hi = (buff_hi << 1) | (buff_lo >> 31)
             buff_hi = buff_hi & 0xFFFFFFFF


### PR DESCRIPTION
We took inspiration from bzip2recover implementation to write the function in charge of finding the chunk end offset.

Need to verify if and how we should mention the original libbzip2 license (simple copyright, no custom licensing).

bzip2 can only act on files so in order to generate content, I simply used this Lorem Ipsum online service:

```
curl http://metaphorpsum.com/sentences/100 > lorem.txt
```