### PR TITLE
Don't emit UnknownChunk for whole files

### DIFF
--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -73,7 +73,7 @@ def test_remove_inner_chunks(
     "chunks, file_size, expected",
     [
         ([], 0, []),
-        ([], 10, [UnknownChunk(0, 0xA)]),
+        ([], 10, []),
         ([ValidChunk(0x0, 0x5)], 5, []),
         ([ValidChunk(0x0, 0x5), ValidChunk(0x5, 0xA)], 10, []),
         ([ValidChunk(0x0, 0x5), ValidChunk(0x5, 0xA)], 12, [UnknownChunk(0xA, 0xC)]),

--- a/unblob/strategies.py
+++ b/unblob/strategies.py
@@ -94,13 +94,10 @@ def calculate_unknown_chunks(
     chunks: List[ValidChunk], file_size: int
 ) -> List[UnknownChunk]:
     """Calculate the empty gaps between chunks."""
-    sorted_by_offset = sorted(chunks, key=attrgetter("start_offset"))
-
-    if file_size == 0:
+    if not chunks or file_size == 0:
         return []
 
-    if not chunks:
-        return [UnknownChunk(0, file_size)]
+    sorted_by_offset = sorted(chunks, key=attrgetter("start_offset"))
 
     unknown_chunks = []
 


### PR DESCRIPTION
by marking whole files as unknown chunks, there is a warning emitted for every
new file extracted which is not desirable, and a handler might pick it up
anyway in the next priority level.
Fixes #77 