### PR TITLE
Cache Git LFS directory

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          lfs: true
 
       - uses: actions/setup-python@v2
         with:
@@ -24,6 +22,19 @@ jobs:
             python -m pip install --upgrade pip
             pip install poetry
             poetry install
+
+      - name: Create LFS file hash list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v2
+        id: lfs-cache
+        with:
+            path: .git/lfs
+            key: lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: git lfs pull
 
       - name: Run pytest
         # TODO: Dummy coverage (branch: 0%) is needed for the pass rate. Increase this


### PR DESCRIPTION
We used ~2Gb bandwidth of Git LFS in 1 day, because every GitHub action
is pulling the Git LFS objects unconditionally and with: lfs: true
doesn't cache pulled LFS objects by default.

By caching the .git/lfs directory it's possible to save that bandwith. The
invalidation logic is that if any of the Git LFS object hash changes or new
files added, it will pull it again.

The implementation is from: https://github.com/actions/checkout/issues/165