### PR TITLE
Add support for LZO compression format.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install 3rd party from apt
         run: |
-            sudo apt install unar zlib1g-dev liblzo2-dev
+            sudo apt install unar zlib1g-dev liblzo2-dev lzop
 
       - name: Install dependencies
         run: |

--- a/tests/integration/compression/lzo/__input__/lorem.filter.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.filter.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69d7b295ff217234203cb4a9b4d60385a295e4f3feca1be42714de0086a26584
+size 6352

--- a/tests/integration/compression/lzo/__input__/lorem.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:480e2c273d8d9106bb3cea12f918978d45db94dab5ba6603c201b1029eb33931
+size 3093

--- a/tests/integration/compression/lzo/__output__/lorem.filter.lzo_extract/0-6352.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.filter.lzo_extract/0-6352.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69d7b295ff217234203cb4a9b4d60385a295e4f3feca1be42714de0086a26584
+size 6352

--- a/tests/integration/compression/lzo/__output__/lorem.filter.lzo_extract/0-6352.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.filter.lzo_extract/0-6352.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.lzo_extract/0-3093.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.lzo_extract/0-3093.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:480e2c273d8d9106bb3cea12f918978d45db94dab5ba6603c201b1029eb33931
+size 3093

--- a/tests/integration/compression/lzo/__output__/lorem.lzo_extract/0-3093.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.lzo_extract/0-3093.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/unblob/handlers/__init__.py
+++ b/unblob/handlers/__init__.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Type
 
 from ..models import Handler
 from .archive import ar, arc, arj, cab, cpio, dmg, rar, sevenzip, tar, zip
+from .compression import lzo
 from .filesystem import cramfs, fat, iso9660, squashfs, ubi
 
 
@@ -33,5 +34,8 @@ _ALL_MODULES_BY_PRIORITY: List[Dict[str, Handler]] = [
         zip.ZIPHandler,
         dmg.DMGHandler,
         iso9660.ISO9660FSHandler,
+    ),
+    _make_handler_map(
+        lzo.LZOHandler,
     ),
 ]

--- a/unblob/handlers/compression/lzo.py
+++ b/unblob/handlers/compression/lzo.py
@@ -1,0 +1,104 @@
+import io
+from typing import List, Optional
+
+from structlog import get_logger
+
+from ...models import StructHandler, ValidChunk
+
+logger = get_logger()
+
+
+F_H_FILTER = 0x00000800
+
+
+class LZOHandler(StructHandler):
+    NAME = "lzo"
+
+    YARA_RULE = r"""
+        strings:
+            $lzo_magic = { 89 4C 5A 4F 00 0D 0A 1A 0A }
+        condition:
+            $lzo_magic
+    """
+
+    C_DEFINITIONS = r"""
+        struct lzo_header_no_filter
+        {
+            char magic[9];
+            uint16 version;
+            uint16 libversion;
+            uint16 reqversion;
+            uint8 method;
+            uint8 level;
+            uint32 flags;
+            //uint32 filter;              // only if flags & F_H_FILTER
+            uint32 mode;
+            uint32 mtime;
+            uint32 gmtdiff;
+            uint8 filename_len;
+            /** The filename length is variable and set by filename_len,
+            so we don't know what's the exact filename char array length
+            at parsing time. Filename parsing is handled in calculate_chunk */
+            //char filename[];
+        }
+
+        struct lzo_header_filter
+        {
+            char magic[9];
+            uint16 version;
+            uint16 libversion;
+            uint16 reqversion;
+            uint8 method;
+            uint8 level;
+            uint32 flags;
+            uint32 filter;              // only if flags & F_H_FILTER
+            uint32 mode;
+            uint32 mtime;
+            uint32 gmtdiff;
+            uint8 filename_len;
+            /** The filename length is variable and set by filename_len,
+            so we don't know what's the exact filename char array length
+            at parsing time. Filename parsing is handled in calculate_chunk */
+            //char filename[];
+        }
+
+        struct lzo_size_crc {
+            uint32 original_crc;        // (CRC32 if flags & F_H_CRC32 else Adler32)
+            uint32 uncompressed_size;
+            uint32 compressed_size;
+            uint32 uncompressed_crc;
+            uint32 compressed_crc;      // (only if flags & F_ADLER32_C or flags & F_CRC32_C)
+        }
+    """
+    HEADER_STRUCT = "lzo_header"
+
+    def calculate_chunk(
+        self, file: io.BufferedIOBase, start_offset: int
+    ) -> Optional[ValidChunk]:
+
+        header = self.cparser_be.lzo_header_no_filter(file)
+
+        if header.flags & F_H_FILTER:
+            file.seek(start_offset)
+            header = self.cparser_be.lzo_header_filter(file)
+
+        filename = file.read(header.filename_len)
+        logger.debug("LZO header parsed", header=header, filename=filename)
+
+        size_crc_header = self.cparser_be.lzo_size_crc(file)
+        logger.debug("CRC header parsed", header=size_crc_header)
+
+        end_offset = (
+            len(header)
+            + header.filename_len
+            + len(size_crc_header)
+            + size_crc_header.compressed_size
+        )
+
+        return ValidChunk(
+            start_offset=start_offset, end_offset=start_offset + end_offset
+        )
+
+    @staticmethod
+    def make_extract_command(inpath: str, outdir: str) -> List[str]:
+        return ["lzop", "-d", "-f", "-N", f"-p{outdir}", inpath]


### PR DESCRIPTION
The LZO file format holds a compressed size value in its header that we can use to calculate the right end offset.

lzop utilities are a requirement to decompress carved out chunks, we added it to Github Action tests.

To compress a file with lzop with highest level of compression (9):

```
lzop -9 -olorem.lzo lorem.txt
```