### PR TITLE
Add LZ4 compression format support.

### DIFF
--- a/tests/integration/compression/lz4/lz4_default/__input__/lorem.block_checksum.lz4
+++ b/tests/integration/compression/lz4/lz4_default/__input__/lorem.block_checksum.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b129044b7d809bce4bb8e49afd07b7d1f5833de5c6f40991416bb5e85c69170c
+size 3944

--- a/tests/integration/compression/lz4/lz4_default/__input__/lorem.csize.lz4
+++ b/tests/integration/compression/lz4/lz4_default/__input__/lorem.csize.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f918be07c7598f1a7a3b3af932fade86baf05bd49967a26b233c2f169b11427e
+size 3948

--- a/tests/integration/compression/lz4/lz4_default/__input__/lorem.no_block_checksum.lz4
+++ b/tests/integration/compression/lz4/lz4_default/__input__/lorem.no_block_checksum.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56dd0270e37aea2fe0ff159aa36c03b84ecfe70e45487762adf43446ca0327fd
+size 3940

--- a/tests/integration/compression/lz4/lz4_default/__input__/lorem.nocsize.lz4
+++ b/tests/integration/compression/lz4/lz4_default/__input__/lorem.nocsize.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56dd0270e37aea2fe0ff159aa36c03b84ecfe70e45487762adf43446ca0327fd
+size 3940

--- a/tests/integration/compression/lz4/lz4_default/__input__/lorem.noframecrc.lz4
+++ b/tests/integration/compression/lz4/lz4_default/__input__/lorem.noframecrc.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cd7d2cebfdd25ae33113fdcc885e4b5df0f7e20ca496ee3fb16ed3852812514
+size 3936

--- a/tests/integration/compression/lz4/lz4_default/__output__/lorem.block_checksum.lz4_extract/0-3944.lz4_default
+++ b/tests/integration/compression/lz4/lz4_default/__output__/lorem.block_checksum.lz4_extract/0-3944.lz4_default
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b129044b7d809bce4bb8e49afd07b7d1f5833de5c6f40991416bb5e85c69170c
+size 3944

--- a/tests/integration/compression/lz4/lz4_default/__output__/lorem.block_checksum.lz4_extract/0-3944.lz4_default_extract/0-3944
+++ b/tests/integration/compression/lz4/lz4_default/__output__/lorem.block_checksum.lz4_extract/0-3944.lz4_default_extract/0-3944
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lz4/lz4_default/__output__/lorem.csize.lz4_extract/0-3948.lz4_default
+++ b/tests/integration/compression/lz4/lz4_default/__output__/lorem.csize.lz4_extract/0-3948.lz4_default
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f918be07c7598f1a7a3b3af932fade86baf05bd49967a26b233c2f169b11427e
+size 3948

--- a/tests/integration/compression/lz4/lz4_default/__output__/lorem.csize.lz4_extract/0-3948.lz4_default_extract/0-3948
+++ b/tests/integration/compression/lz4/lz4_default/__output__/lorem.csize.lz4_extract/0-3948.lz4_default_extract/0-3948
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lz4/lz4_default/__output__/lorem.no_block_checksum.lz4_extract/0-3940.lz4_default
+++ b/tests/integration/compression/lz4/lz4_default/__output__/lorem.no_block_checksum.lz4_extract/0-3940.lz4_default
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56dd0270e37aea2fe0ff159aa36c03b84ecfe70e45487762adf43446ca0327fd
+size 3940

--- a/tests/integration/compression/lz4/lz4_default/__output__/lorem.no_block_checksum.lz4_extract/0-3940.lz4_default_extract/0-3940
+++ b/tests/integration/compression/lz4/lz4_default/__output__/lorem.no_block_checksum.lz4_extract/0-3940.lz4_default_extract/0-3940
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lz4/lz4_default/__output__/lorem.nocsize.lz4_extract/0-3940.lz4_default
+++ b/tests/integration/compression/lz4/lz4_default/__output__/lorem.nocsize.lz4_extract/0-3940.lz4_default
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56dd0270e37aea2fe0ff159aa36c03b84ecfe70e45487762adf43446ca0327fd
+size 3940

--- a/tests/integration/compression/lz4/lz4_default/__output__/lorem.nocsize.lz4_extract/0-3940.lz4_default_extract/0-3940
+++ b/tests/integration/compression/lz4/lz4_default/__output__/lorem.nocsize.lz4_extract/0-3940.lz4_default_extract/0-3940
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lz4/lz4_default/__output__/lorem.noframecrc.lz4_extract/0-3936.lz4_default
+++ b/tests/integration/compression/lz4/lz4_default/__output__/lorem.noframecrc.lz4_extract/0-3936.lz4_default
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cd7d2cebfdd25ae33113fdcc885e4b5df0f7e20ca496ee3fb16ed3852812514
+size 3936

--- a/tests/integration/compression/lz4/lz4_default/__output__/lorem.noframecrc.lz4_extract/0-3936.lz4_default_extract/0-3936
+++ b/tests/integration/compression/lz4/lz4_default/__output__/lorem.noframecrc.lz4_extract/0-3936.lz4_default_extract/0-3936
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lz4/lz4_legacy/__input__/lorem.legacy.lz4
+++ b/tests/integration/compression/lz4/lz4_legacy/__input__/lorem.legacy.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:174728566a2e5a268d16873ecc3de115239d99129177556d6dbd507719f336c8
+size 3929

--- a/tests/integration/compression/lz4/lz4_legacy/__output__/lorem.legacy.lz4_extract/0-3929.lz4_legacy
+++ b/tests/integration/compression/lz4/lz4_legacy/__output__/lorem.legacy.lz4_extract/0-3929.lz4_legacy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:174728566a2e5a268d16873ecc3de115239d99129177556d6dbd507719f336c8
+size 3929

--- a/tests/integration/compression/lz4/lz4_legacy/__output__/lorem.legacy.lz4_extract/0-3929.lz4_legacy_extract/0-3929
+++ b/tests/integration/compression/lz4/lz4_legacy/__output__/lorem.legacy.lz4_extract/0-3929.lz4_legacy_extract/0-3929
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lz4/lz4_skippable/__input__/skippable.lz4
+++ b/tests/integration/compression/lz4/lz4_skippable/__input__/skippable.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65090d5f19366d988768d5b10f3e5bc6d51dcd6c0459b4784b1ee71a4bc3a081
+size 108

--- a/tests/integration/compression/lz4/lz4_skippable/__output__/skippable.lz4_extract/0-108.lz4_skippable
+++ b/tests/integration/compression/lz4/lz4_skippable/__output__/skippable.lz4_extract/0-108.lz4_skippable
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65090d5f19366d988768d5b10f3e5bc6d51dcd6c0459b4784b1ee71a4bc3a081
+size 108

--- a/unblob/handlers/__init__.py
+++ b/unblob/handlers/__init__.py
@@ -2,7 +2,7 @@ from typing import List, Tuple, Type
 
 from ..models import Handler
 from .archive import ar, arc, arj, cab, cpio, dmg, rar, sevenzip, tar, zip
-from .compression import bzip2, lzip, lzma, lzo, xz
+from .compression import bzip2, lz4, lzip, lzma, lzo, xz
 from .filesystem import cramfs, fat, iso9660, squashfs, ubi
 
 ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
@@ -35,6 +35,9 @@ ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
         lzip.LZipHandler,
         lzo.LZOHandler,
         lzma.LZMAHandler,
+        lz4.LegacyFrameHandler,
+        lz4.SkippableFrameHandler,
+        lz4.DefaultFrameHandler,
         xz.XZHandler,
     ),
 ]

--- a/unblob/handlers/compression/lz4.py
+++ b/unblob/handlers/compression/lz4.py
@@ -1,0 +1,182 @@
+"""
+LZ4 frame format definition: https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md
+"""
+import io
+from pathlib import Path
+from typing import List, Optional
+
+from structlog import get_logger
+
+from ...file_utils import Endian, convert_int8, convert_int32
+from ...models import Handler, ValidChunk
+
+logger = get_logger()
+
+SKIPPABLE_FRAMES_MAGIC = [0x184D2A50 + i for i in range(0, 16)]
+FRAME_MAGIC = 0x184D2204
+LEGACY_FRAME_MAGIC = 0x184C2102
+FRAME_MAGICS = SKIPPABLE_FRAMES_MAGIC + [FRAME_MAGIC] + [LEGACY_FRAME_MAGIC]
+
+_1BIT = 0x01
+_2BITS = 0x03
+
+END_MARK = 0x00000000
+
+CONTENT_SIZE_LEN = 8
+BLOCK_SIZE_LEN = (
+    FRAME_SIZE_LEN
+) = BLOCK_CHECKSUM_LEN = CONTENT_CHECKSUM_LEN = MAGIC_LEN = DICTID_LEN = 4
+FLG_LEN = BD_LEN = HC_LEN = 1
+
+
+class FLG:
+    """Represents the FLG field"""
+
+    version: int = 0
+    block_independence: int = 0
+    block_checksum: int = 0
+    content_size: int = 0
+    content_checksum: int = 0
+    dictid: int = 0
+
+    def __init__(self, raw_flg: int):
+        self.version = (raw_flg >> 6) & _2BITS
+        self.block_independence = (raw_flg >> 5) & _1BIT
+        self.block_checksum = (raw_flg >> 4) & _1BIT
+        self.content_size = (raw_flg >> 3) & _1BIT
+        self.content_checksum = (raw_flg >> 2) & _1BIT
+        self.dictid = raw_flg & _1BIT
+
+    def as_dict(self) -> dict:
+        return {
+            "version": self.version,
+            "block_independence": self.block_independence,
+            "block_checksum": self.block_checksum,
+            "content_size": self.content_size,
+            "content_checksum": self.content_checksum,
+            "dictid": self.dictid,
+        }
+
+
+class _LZ4HandlerBase(Handler):
+    """A common base for all LZ4 formats."""
+
+    @staticmethod
+    def make_extract_command(inpath: str, outdir: str) -> List[str]:
+        outfile = Path(inpath).stem
+        return ["lz4", "--decompress", inpath, f"{outdir}/{outfile}"]
+
+    def _skip_magic_bytes(self, file: io.BufferedIOBase):
+        file.read(MAGIC_LEN)
+
+
+class LegacyFrameHandler(_LZ4HandlerBase):
+    NAME = "lz4_legacy"
+    YARA_RULE = r"""
+        strings:
+            $lz4_legacy_frame = { 02 21 4C 18 }
+        condition:
+            $lz4_legacy_frame
+    """
+
+    def calculate_chunk(
+        self, file: io.BufferedIOBase, start_offset: int
+    ) -> Optional[ValidChunk]:
+
+        self._skip_magic_bytes(file)
+
+        while True:
+            # The last block is detected either because it is followed by the “EOF” (End of File) mark,
+            # or because it is followed by a known Frame Magic Number.
+            raw_bsize = file.read(BLOCK_SIZE_LEN)
+            if raw_bsize == b"":  # EOF
+                break
+
+            block_compressed_size = convert_int32(raw_bsize, Endian.LITTLE)
+            if block_compressed_size in FRAME_MAGICS:
+                # next magic, read too far
+                file.seek(-4, io.SEEK_CUR)
+                break
+
+            file.read(block_compressed_size)
+
+        end_offset = file.tell()
+        return ValidChunk(start_offset=start_offset, end_offset=end_offset)
+
+
+class SkippableFrameHandler(_LZ4HandlerBase):
+    """This can be anything, basically uncompressed data."""
+
+    NAME = "lz4_skippable"
+    YARA_RULE = r"""
+        strings:
+            $lz4_skippable_frame = { 5? 2A 4D 18 }
+        condition:
+            $lz4_skippable_frame
+    """
+
+    def calculate_chunk(
+        self, file: io.BufferedIOBase, start_offset: int
+    ) -> Optional[ValidChunk]:
+        self._skip_magic_bytes(file)
+        frame_size = convert_int32(file.read(FRAME_SIZE_LEN), Endian.LITTLE)
+        file.read(frame_size)
+        end_offset = file.tell()
+        return ValidChunk(start_offset=start_offset, end_offset=end_offset)
+
+
+class DefaultFrameHandler(_LZ4HandlerBase):
+    """This is the modern version, most frequently used."""
+
+    NAME = "lz4_default"
+
+    YARA_RULE = r"""
+        strings:
+            $lz4_default_frame = { 04 22 4D 18 }
+
+        condition:
+            $lz4_default_frame
+    """
+
+    def calculate_chunk(  # noqa: C901
+        self, file: io.BufferedIOBase, start_offset: int
+    ) -> Optional[ValidChunk]:
+
+        self._skip_magic_bytes(file)
+
+        # 2. we parse the frame descriptor of dynamic size
+        flg_bytes = file.read(FLG_LEN)
+        raw_flg = convert_int8(flg_bytes, Endian.LITTLE)
+        flg = FLG(raw_flg)
+        logger.debug("Parsed FLG", **flg.as_dict())
+
+        # skip BD (max blocksize), only useful for decoders that needs to allocate memory
+        file.read(BD_LEN)
+
+        if flg.content_size:
+            file.read(CONTENT_SIZE_LEN)
+        if flg.dictid:
+            file.read(DICTID_LEN)
+
+        header_checksum = convert_int8(file.read(HC_LEN), Endian.LITTLE)
+        logger.debug("Header checksum (HC) read", header_checksum=header_checksum)
+
+        # 3. we read block by block until we hit the endmarker
+        while True:
+            block_size = convert_int32(file.read(BLOCK_SIZE_LEN), Endian.LITTLE)
+            logger.debug("block_size", block_size=block_size)
+            if block_size == END_MARK:
+                break
+            file.read(block_size)
+            if flg.block_checksum:
+                file.read(BLOCK_CHECKSUM_LEN)
+
+        # 4. we reached the endmark (0x00000000)
+
+        # 5. if frame descriptor mentions CRC, we add CRC
+        if flg.content_checksum:
+            file.read(CONTENT_CHECKSUM_LEN)
+
+        end_offset = file.tell()
+
+        return ValidChunk(start_offset=start_offset, end_offset=end_offset)


### PR DESCRIPTION
All length calculation and header parsing are based on official LZ4 frame description available at https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md.

All integration test files, with the exception of skippable frames, were generated using lz4 command line tool. Test files cover all header flags combinations. Skippable frame file was generated programmatically given that lz4 command line does not support
creating such frames.