### PR TITLE
Add support for XZ compression format.

### DIFF
--- a/tests/integration/compression/xz/__input__/lorem.txt.xz
+++ b/tests/integration/compression/xz/__input__/lorem.txt.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:697759ccdb7e21ee1a099e2fbf9eeb888935b6753c8837c8ab3dba1bc5e2a9c7
+size 2632

--- a/tests/integration/compression/xz/__output__/lorem.txt.xz_extract/0-2632.xz
+++ b/tests/integration/compression/xz/__output__/lorem.txt.xz_extract/0-2632.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:697759ccdb7e21ee1a099e2fbf9eeb888935b6753c8837c8ab3dba1bc5e2a9c7
+size 2632

--- a/tests/integration/compression/xz/__output__/lorem.txt.xz_extract/0-2632.xz_extract/0-2632
+++ b/tests/integration/compression/xz/__output__/lorem.txt.xz_extract/0-2632.xz_extract/0-2632
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb3492cf53eff7ec69d48b65b923668dd36e80524a2c45d52eae45597a8c8502
+size 6662

--- a/unblob/handlers/__init__.py
+++ b/unblob/handlers/__init__.py
@@ -2,7 +2,7 @@ from typing import List, Tuple, Type
 
 from ..models import Handler
 from .archive import ar, arc, arj, cab, cpio, dmg, rar, sevenzip, tar, zip
-from .compression import bzip2, lzo
+from .compression import bzip2, lzo, xz
 from .filesystem import cramfs, fat, iso9660, squashfs, ubi
 
 ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
@@ -33,5 +33,6 @@ ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
     (
         bzip2.BZip2Handler,
         lzo.LZOHandler,
+        xz.XZHandler,
     ),
 ]

--- a/unblob/handlers/archive/zip.py
+++ b/unblob/handlers/archive/zip.py
@@ -113,7 +113,7 @@ class ZIPHandler(StructHandler):
 
         file.seek(start_offset)
 
-        zip_end = find_first(file, EOCD_RECORD_HEADER) + start_offset
+        zip_end = find_first(file, EOCD_RECORD_HEADER)
 
         if zip_end == -1:
             raise MissingEOCDHeader

--- a/unblob/handlers/compression/xz.py
+++ b/unblob/handlers/compression/xz.py
@@ -1,0 +1,114 @@
+import io
+from typing import List, Optional, Tuple
+
+from structlog import get_logger
+
+from ...file_utils import (
+    Endian,
+    convert_int8,
+    convert_int32,
+    decode_multibyte_integer,
+    iterate_patterns,
+    round_up,
+)
+from ...models import Handler, ValidChunk
+
+logger = get_logger()
+
+# The .xz file format definition: https://tukaani.org/xz/xz-file-format-1.0.4.txt
+
+XZ_PADDING = 4  # XZ format byte alignment
+MAX_MBI_LEN = 9  # maximum multi-byte integer size is 9, per XZ standard
+STREAM_HEADER_SIZE = 12  # magic bytes (6) + flags (2) + CRC32 (4)
+STREAM_FOOTER_SIZE = 12  # CRC32 (4) + backward size (4) + flags (2) + magic bytes (2)
+STREAM_FOOTER_MAGIC = b"YZ"
+
+MAGIC_BYTES_SIZE = 6
+BACKWARD_SIZE_LEN = 4
+CRC32_LEN = 4
+FLAG_LEN = 2
+
+
+def read_multibyte_int(file: io.BufferedIOBase) -> Tuple[int, int]:
+    """Read a multibyte integer and return the number of bytes read and the integer itself."""
+    data = bytearray(file.read(MAX_MBI_LEN))
+    file.seek(-MAX_MBI_LEN, io.SEEK_CUR)
+    size, mbi = decode_multibyte_integer(data)
+    file.read(size)
+    return size, mbi
+
+
+class XZHandler(Handler):
+    NAME = "xz"
+
+    YARA_RULE = r"""
+        strings:
+            $xz_stream_header_magic = { FD 37 7A 58 5A 00 }
+        condition:
+            $xz_stream_header_magic
+    """
+
+    def calculate_chunk(
+        self, file: io.BufferedIOBase, start_offset: int
+    ) -> Optional[ValidChunk]:
+
+        file.read(MAGIC_BYTES_SIZE)
+        stream_flags = file.read(FLAG_LEN)
+        file.seek(start_offset)
+
+        for footer_offset in iterate_patterns(file, stream_flags + STREAM_FOOTER_MAGIC):
+            # make sure it's byte aligned
+            if (footer_offset - start_offset) % 4 != 0:
+                continue
+
+            end_offset = start_offset + footer_offset + CRC32_LEN
+
+            file.seek(footer_offset - BACKWARD_SIZE_LEN)
+
+            backward_bytes = file.read(BACKWARD_SIZE_LEN)
+            stored_backward_size = convert_int32(backward_bytes, Endian.LITTLE)
+            real_backward_size = (stored_backward_size + 1) * 4
+
+            file.seek(-CRC32_LEN - BACKWARD_SIZE_LEN, io.SEEK_CUR)
+            # skip backwards of backward size to the start of index
+            file.seek(-real_backward_size, io.SEEK_CUR)
+
+            index_size = 0
+            index_indicator = convert_int8(file.read(1), Endian.LITTLE)
+            # index indicator must be 0, per xz standard
+            if index_indicator != 0:
+                continue
+
+            index_size += 1
+
+            # read Index 'Number of Records'
+            size, num_records = read_multibyte_int(file)
+            index_size += size
+
+            # read Record 'Unpadded Size' and 'Uncompressed Size' for every Record
+            blocks_size = 0
+            for _ in range(0, num_records):
+                size, unpadded_size = read_multibyte_int(file)
+                index_size += size
+
+                size, uncompressed_size = read_multibyte_int(file)
+                index_size += size
+
+                blocks_size += unpadded_size
+
+            index_size += CRC32_LEN
+
+            overall_size = round_up(
+                (STREAM_HEADER_SIZE + blocks_size + index_size + STREAM_FOOTER_SIZE),
+                XZ_PADDING,
+            )
+
+            # if the identified chunk size is equal to the size calculated from
+            # the Index's records, that means we matched on the right footer and
+            # we can return
+            if (end_offset - start_offset) == overall_size:
+                return ValidChunk(start_offset=start_offset, end_offset=end_offset)
+
+    @staticmethod
+    def make_extract_command(inpath: str, outdir: str) -> List[str]:
+        return ["7z", "x", "-y", inpath, f"-o{outdir}"]

--- a/unblob/handlers/filesystem/ubi.py
+++ b/unblob/handlers/filesystem/ubi.py
@@ -131,12 +131,10 @@ class UBIHandler(Handler):
         # cause an issue if we had a blob containing multiple UBI images, with different PEB sizes.
         all_ubi_eraseblock_offsets = []
         while True:
-            start_find = file.tell()
             offset = find_first(file, self._UBI_EC_HEADER)
-            file.seek(offset + len(self._UBI_EC_HEADER) + start_find)
             if offset == -1:
                 break
-            all_ubi_eraseblock_offsets.append(start_find + offset)
+            all_ubi_eraseblock_offsets.append(offset)
 
         offset_intervals = get_intervals(all_ubi_eraseblock_offsets)
         if not offset_intervals:


### PR DESCRIPTION
The handler was written based on the .xz file format definition available at https://tukaani.org/xz/xz-file-format-1.0.4.txt

Test files were generated using the `xz` CLI tool:

```
xz -z lorem.txt
```

A function was added to file_utils (decode_multibyte_integer) to convert multi-bytes integer from a byte array into a tuple of integer representing the integer size and value. Multi-byte integers are documented in section 1.2 of the XZ file format standard. Unit tests covering this function are present in test_file_utils.