### PR TITLE
Add support for LZMA compression format.

### DIFF
--- a/tests/integration/compression/lzma/__input__/lorem.txt.lzma
+++ b/tests/integration/compression/lzma/__input__/lorem.txt.lzma
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70c73589d48f0330532803fa18b227e534eef005d298405bd6e63024d5d5c148
+size 2550

--- a/tests/integration/compression/lzma/__input__/lorem.txt.unused.lzma
+++ b/tests/integration/compression/lzma/__input__/lorem.txt.unused.lzma
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:819766ed96a23a6133523a1a9c3354af5904d9ee2f34d16613759a0b5e58602b
+size 2590

--- a/tests/integration/compression/lzma/__output__/lorem.txt.lzma_extract/0-2550.lzma
+++ b/tests/integration/compression/lzma/__output__/lorem.txt.lzma_extract/0-2550.lzma
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70c73589d48f0330532803fa18b227e534eef005d298405bd6e63024d5d5c148
+size 2550

--- a/tests/integration/compression/lzma/__output__/lorem.txt.lzma_extract/0-2550.lzma_extract/0-2550
+++ b/tests/integration/compression/lzma/__output__/lorem.txt.lzma_extract/0-2550.lzma_extract/0-2550
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f6d7f33aca4af63fb80e693319b0986b612c9a004977cecebb3c0040a538c26
+size 6116

--- a/tests/integration/compression/lzma/__output__/lorem.txt.unused.lzma_extract/0-2550.lzma
+++ b/tests/integration/compression/lzma/__output__/lorem.txt.unused.lzma_extract/0-2550.lzma
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70c73589d48f0330532803fa18b227e534eef005d298405bd6e63024d5d5c148
+size 2550

--- a/tests/integration/compression/lzma/__output__/lorem.txt.unused.lzma_extract/0-2550.lzma_extract/0-2550
+++ b/tests/integration/compression/lzma/__output__/lorem.txt.unused.lzma_extract/0-2550.lzma_extract/0-2550
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f6d7f33aca4af63fb80e693319b0986b612c9a004977cecebb3c0040a538c26
+size 6116

--- a/tests/integration/compression/lzma/__output__/lorem.txt.unused.lzma_extract/2550-2590.unknown
+++ b/tests/integration/compression/lzma/__output__/lorem.txt.unused.lzma_extract/2550-2590.unknown
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97c36e66f0891aabb48d63a96b11b3fb642d2916d22e62929e06bd100a73c608
+size 40

--- a/unblob/handlers/__init__.py
+++ b/unblob/handlers/__init__.py
@@ -2,7 +2,7 @@ from typing import List, Tuple, Type
 
 from ..models import Handler
 from .archive import ar, arc, arj, cab, cpio, dmg, rar, sevenzip, tar, zip
-from .compression import bzip2, lzip, lzo, xz
+from .compression import bzip2, lzip, lzma, lzo, xz
 from .filesystem import cramfs, fat, iso9660, squashfs, ubi
 
 ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
@@ -34,6 +34,7 @@ ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
         bzip2.BZip2Handler,
         lzip.LZipHandler,
         lzo.LZOHandler,
+        lzma.LZMAHandler,
         xz.XZHandler,
     ),
 ]

--- a/unblob/handlers/compression/lzma.py
+++ b/unblob/handlers/compression/lzma.py
@@ -1,0 +1,52 @@
+import io
+import lzma
+from typing import List, Optional
+
+from structlog import get_logger
+
+from unblob.file_utils import find_first
+
+from ...models import Handler, ValidChunk
+
+logger = get_logger()
+
+
+class LZMAHandler(Handler):
+    NAME = "lzma"
+
+    YARA_RULE = r"""
+        strings:
+            $lzma_magic = { 5d 00 00 ( 00 | 01 | 04 | 08 | 10 | 20 | 40 | 80) ( 00 | 01 | 02 | 04 | 08 ) }
+        condition:
+            $lzma_magic
+    """
+
+    def calculate_chunk(
+        self, file: io.BufferedIOBase, start_offset: int
+    ) -> Optional[ValidChunk]:
+
+        decompressor = lzma.LZMADecompressor(format=lzma.FORMAT_ALONE)
+        try:
+            decompressor.decompress(file.read())
+        except lzma.LZMAError:
+            return
+
+        # unused_data contains data found after the end of the compressed stream, if any.
+        # we can search for that needle within the file to find the end offset :)
+        if decompressor.unused_data != b"":
+            file.seek(start_offset)
+            end_offset = find_first(
+                file,
+                decompressor.unused_data[0:16],
+            )
+        else:
+            file.seek(0, io.SEEK_END)
+            end_offset = file.tell()
+
+        return ValidChunk(
+            start_offset=start_offset, end_offset=start_offset + end_offset
+        )
+
+    @staticmethod
+    def make_extract_command(inpath: str, outdir: str) -> List[str]:
+        return ["7z", "x", "-y", inpath, f"-o{outdir}"]


### PR DESCRIPTION
We take advantage of Python 3's lzma built-in library (available since version 3.3) to identify the end offset of a given chunk.

LZMA file format standard: https://svn.python.org/projects/external/xz-5.0.3/doc/lzma-file-format.txt

Two test files are provided to action every branch in the `calculate_chunk `function:
- one with an LZMA stream only
- one with an LZMA stream and garbage at the end

These files were built this way:

```
curl http://metaphorpsum.com/sentences/100 > lorem.txt
lzma -k -z lorem.txt
echo 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAa' > a.bin
cat lorem.txt.lzma a.bin > lorem.txt.unused.lzma
```

