### PR TITLE
Add support for LZIP compression format.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install 3rd party from apt
         run: |
-            sudo apt install unar zlib1g-dev liblzo2-dev lzop
+            sudo apt install unar zlib1g-dev liblzo2-dev lzop lziprecover
 
       - name: Install dependencies
         run: |

--- a/tests/integration/compression/lzip/__input__/lorem.txt.lz
+++ b/tests/integration/compression/lzip/__input__/lorem.txt.lz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b92a810e9381f7103ba177c36e39033984153347a4be0104aa824c571b3bf366
+size 2520

--- a/tests/integration/compression/lzip/__output__/lorem.txt.lz_extract/0-2520.lzip
+++ b/tests/integration/compression/lzip/__output__/lorem.txt.lz_extract/0-2520.lzip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b92a810e9381f7103ba177c36e39033984153347a4be0104aa824c571b3bf366
+size 2520

--- a/tests/integration/compression/lzip/__output__/lorem.txt.lz_extract/0-2520.lzip_extract/0-2520
+++ b/tests/integration/compression/lzip/__output__/lorem.txt.lz_extract/0-2520.lzip_extract/0-2520
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd1527cd2c67d12b392059f1e6b1bcd1e922c05351db37e3b62393372d8f0917
+size 6064

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -114,7 +114,7 @@ class TestConvertInt8:
             (b"\x10", Endian.BIG, 0x10),
         ),
     )
-    def test_convert_int8(self, value, endian, expected):
+    def test_convert_int8(self, value: bytes, endian: Endian, expected: int):
         assert convert_int8(value, endian) == expected
 
     @pytest.mark.parametrize(
@@ -130,7 +130,7 @@ class TestConvertInt8:
             (b"\xff\xff\xff\xff\xff", Endian.BIG),
         ),
     )
-    def test_convert_invalid_values(self, value, endian):
+    def test_convert_invalid_values(self, value: bytes, endian: Endian):
         with pytest.raises(ValueError):
             convert_int8(value, endian)
 
@@ -147,7 +147,7 @@ class TestConvertInt32:
             (b"\x10\x00\x00\x00", Endian.BIG, 0x10000000),
         ),
     )
-    def test_convert_int32(self, value, endian, expected):
+    def test_convert_int32(self, value: bytes, endian: Endian, expected: int):
         assert convert_int32(value, endian) == expected
 
     @pytest.mark.parametrize(
@@ -165,7 +165,7 @@ class TestConvertInt32:
             (b"\xff\xff\xff\xff\xff", Endian.BIG),
         ),
     )
-    def test_convert_invalid_values(self, value, endian):
+    def test_convert_invalid_values(self, value: bytes, endian: Endian):
         with pytest.raises(ValueError):
             convert_int32(value, endian)
 
@@ -182,7 +182,7 @@ class TestConvertInt64:
             (b"\x10\x00\x00\x00\x00\x00\x00\x00", Endian.BIG, 0x1000_0000_0000_0000),
         ),
     )
-    def test_convert_int64(self, value, endian, expected):
+    def test_convert_int64(self, value: bytes, endian: Endian, expected: int):
         assert convert_int64(value, endian) == expected
 
     @pytest.mark.parametrize(
@@ -206,7 +206,7 @@ class TestConvertInt64:
             (b"\xff\xff\xff\xff\xff\xff\xff", Endian.BIG),
         ),
     )
-    def test_convert_invalid_values(self, value, endian):
+    def test_convert_invalid_values(self, value: bytes, endian: Endian):
         with pytest.raises(ValueError):
             convert_int64(value, endian)
 
@@ -225,7 +225,7 @@ class TestMultibytesInteger:
             (b"\xff\xff\xff\xff\xff\xff\xff\x7f", (8, 0xFFFFFFFFFFFFFF)),
         ),
     )
-    def test_decode_multibyte_integer(self, value, expected):
+    def test_decode_multibyte_integer(self, value: bytes, expected: int):
         assert decode_multibyte_integer(value) == expected
 
     @pytest.mark.parametrize(
@@ -236,7 +236,7 @@ class TestMultibytesInteger:
             (b"\xff\xff\xff"),
         ),
     )
-    def test_decode_invalid_values(self, value):
+    def test_decode_invalid_values(self, value: bytes):
         with pytest.raises(ValueError):
             decode_multibyte_integer(value)
 

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -10,6 +10,7 @@ from unblob.file_utils import (
     StructParser,
     convert_int8,
     convert_int32,
+    convert_int64,
     decode_multibyte_integer,
     find_first,
     iterate_file,
@@ -167,6 +168,47 @@ class TestConvertInt32:
     def test_convert_invalid_values(self, value, endian):
         with pytest.raises(ValueError):
             convert_int32(value, endian)
+
+
+class TestConvertInt64:
+    @pytest.mark.parametrize(
+        "value, endian, expected",
+        (
+            (b"\x00\x00\x00\x00\x00\x00\x00\x00", Endian.LITTLE, 0x0),
+            (b"\x00\x00\x00\x00\x00\x00\x00\x00", Endian.BIG, 0x0),
+            (b"\xff\xff\xff\xff\xff\xff\xff\xff", Endian.LITTLE, 0xFFFF_FFFF_FFFF_FFFF),
+            (b"\xff\xff\xff\xff\xff\xff\xff\xff", Endian.BIG, 0xFFFF_FFFF_FFFF_FFFF),
+            (b"\x10\x00\x00\x00\x00\x00\x00\x00", Endian.LITTLE, 0x10),
+            (b"\x10\x00\x00\x00\x00\x00\x00\x00", Endian.BIG, 0x1000_0000_0000_0000),
+        ),
+    )
+    def test_convert_int64(self, value, endian, expected):
+        assert convert_int64(value, endian) == expected
+
+    @pytest.mark.parametrize(
+        "value, endian",
+        (
+            (b"", Endian.LITTLE),
+            (b"", Endian.BIG),
+            (b"\x00", Endian.LITTLE),
+            (b"\x00", Endian.BIG),
+            (b"\x00\x00", Endian.LITTLE),
+            (b"\x00\x00", Endian.BIG),
+            (b"\xff\xff\xff", Endian.LITTLE),
+            (b"\xff\xff\xff", Endian.BIG),
+            (b"\xff\xff\xff\xff", Endian.LITTLE),
+            (b"\xff\xff\xff\xff", Endian.BIG),
+            (b"\xff\xff\xff\xff\xff", Endian.LITTLE),
+            (b"\xff\xff\xff\xff\xff", Endian.BIG),
+            (b"\xff\xff\xff\xff\xff\xff", Endian.LITTLE),
+            (b"\xff\xff\xff\xff\xff\xff", Endian.BIG),
+            (b"\xff\xff\xff\xff\xff\xff\xff", Endian.LITTLE),
+            (b"\xff\xff\xff\xff\xff\xff\xff", Endian.BIG),
+        ),
+    )
+    def test_convert_invalid_values(self, value, endian):
+        with pytest.raises(ValueError):
+            convert_int64(value, endian)
 
 
 class TestMultibytesInteger:

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -52,6 +52,14 @@ def convert_int32(value: bytes, endian: Endian) -> int:
         raise ValueError("Not an int32")
 
 
+def convert_int64(value: bytes, endian: Endian) -> int:
+    """Convert 8 byte integer to a Python int."""
+    try:
+        return struct.unpack(f"{endian.value}Q", value)[0]
+    except struct.error:
+        raise ValueError("Not an int64")
+
+
 def decode_multibyte_integer(data: bytes) -> Tuple[int, int]:
     """Decodes multi-bytes integer into integer size and integer value.
 

--- a/unblob/handlers/__init__.py
+++ b/unblob/handlers/__init__.py
@@ -2,7 +2,7 @@ from typing import List, Tuple, Type
 
 from ..models import Handler
 from .archive import ar, arc, arj, cab, cpio, dmg, rar, sevenzip, tar, zip
-from .compression import bzip2, lzo, xz
+from .compression import bzip2, lzip, lzo, xz
 from .filesystem import cramfs, fat, iso9660, squashfs, ubi
 
 ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
@@ -32,6 +32,7 @@ ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
     ),
     (
         bzip2.BZip2Handler,
+        lzip.LZipHandler,
         lzo.LZOHandler,
         xz.XZHandler,
     ),

--- a/unblob/handlers/compression/lzip.py
+++ b/unblob/handlers/compression/lzip.py
@@ -1,0 +1,55 @@
+import io
+from pathlib import Path
+from typing import List, Optional
+
+from structlog import get_logger
+
+from ...file_utils import Endian, convert_int64
+from ...models import Handler, ValidChunk
+
+logger = get_logger()
+
+# magic (4 bytes) + VN (1 byte) + DS (1 byte)
+HEADER_LEN = 4 + 1 + 1
+# LZMA stream is 2 bytes aligned
+LZMA_ALIGNMENT = 2
+
+
+class LZipHandler(Handler):
+    NAME = "lzip"
+
+    YARA_RULE = r"""
+        strings:
+            $lzip_magic = { 4C 5A 49 50 01 }
+        condition:
+            $lzip_magic
+    """
+
+    def calculate_chunk(
+        self, file: io.BufferedIOBase, start_offset: int
+    ) -> Optional[ValidChunk]:
+
+        file.read(HEADER_LEN)
+        # quite the naive idea but it works
+        # the idea is to read 8 bytes uint64 every 2 bytes alignment
+        # until we end up reading the Member Size field which corresponds
+        # to "the total size of the member, including header and trailer".
+        # We either find it or reach EOF, which will be caught by finder.
+
+        while True:
+            file.seek(LZMA_ALIGNMENT, io.SEEK_CUR)
+            try:
+                member_size = convert_int64(file.read(8), Endian.LITTLE)
+            except ValueError:
+                return
+            if member_size == (file.tell() - start_offset):
+                end_offset = file.tell()
+                break
+            file.seek(-8, io.SEEK_CUR)
+
+        return ValidChunk(start_offset=start_offset, end_offset=end_offset)
+
+    @staticmethod
+    def make_extract_command(inpath: str, outdir: str) -> List[str]:
+        outfile = Path(inpath).stem
+        return ["lziprecover", "-k", "-D0", "-i", inpath, "-o", f"{outdir}/{outfile}"]


### PR DESCRIPTION
LZIP handler properly detects the LZIP magic and apply a naive approach derived from the LZIP standard  (https://datatracker.ietf.org/doc/html/draft-diaz-lzip) to identify the end offset of identified chunk.

The idea is to read an 8 bytes uint64 every 2 bytes alignment (this is the alignment of LZMA stream which is the central part of any LZIP compressed file) until we read a value that corresponds to 'Member size'.

Member size is the 'total size of the member, including header and trailer.', so when we read this value it _must_ correspond to our position in the file, minus the start offset.

We use `lziprecover` as extraction binary because it's the only lzip extractor that supports and explicit user controlled output file.

Test files can be created with lzip:

```
lzip yourfile.txt
file yourfile.txt.lz
yourfile.txt.lz: lzip compressed data, version: 1
```
