### PR TITLE
Add support for StuffIt archive file format.

### DIFF
--- a/tests/integration/archive/stuffit/stuffit5/__input__/plum.sit5
+++ b/tests/integration/archive/stuffit/stuffit5/__input__/plum.sit5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:170c8d226dad8fd1802c735911893b7774ce8fec4d6acb3170eec0eca3ddf64a
+size 534

--- a/tests/integration/archive/stuffit/stuffit5/__output__/plum.sit5_extract/0-534.stuffit5
+++ b/tests/integration/archive/stuffit/stuffit5/__output__/plum.sit5_extract/0-534.stuffit5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:170c8d226dad8fd1802c735911893b7774ce8fec4d6acb3170eec0eca3ddf64a
+size 534

--- a/tests/integration/archive/stuffit/stuffit5/__output__/plum.sit5_extract/0-534.stuffit5_extract/0-534/plum1.txt
+++ b/tests/integration/archive/stuffit/stuffit5/__output__/plum.sit5_extract/0-534.stuffit5_extract/0-534/plum1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c44d2870876585339fb82a9377a865dfab48005893f7df8e21bf17566bb15a9c
+size 6

--- a/tests/integration/archive/stuffit/stuffit5/__output__/plum.sit5_extract/0-534.stuffit5_extract/0-534/plum2.txt
+++ b/tests/integration/archive/stuffit/stuffit5/__output__/plum.sit5_extract/0-534.stuffit5_extract/0-534/plum2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7e4f4c206539eb3f4bebb13a50c996ea763f5a82fe7130cc315921485fb8087
+size 6

--- a/tests/integration/archive/stuffit/stuffit5/__output__/plum.sit5_extract/0-534.stuffit5_extract/0-534/plum3.txt
+++ b/tests/integration/archive/stuffit/stuffit5/__output__/plum.sit5_extract/0-534.stuffit5_extract/0-534/plum3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0e8cc9f53bfb0de5f45deb88c343f530dcbfeb30b0af37e683a185664b63be0
+size 6

--- a/tests/integration/archive/stuffit/stuffit5/__output__/plum.sit5_extract/0-534.stuffit5_extract/0-534/plum4.txt
+++ b/tests/integration/archive/stuffit/stuffit5/__output__/plum.sit5_extract/0-534.stuffit5_extract/0-534/plum4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10195422714841b86cf43bf83013b9183f697452125430a774da43f862527486
+size 6

--- a/unblob/handlers/__init__.py
+++ b/unblob/handlers/__init__.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple, Type
 
 from ..models import Handler
-from .archive import ar, arc, arj, cab, cpio, dmg, rar, sevenzip, tar, zip
+from .archive import ar, arc, arj, cab, cpio, dmg, rar, sevenzip, stuffit, tar, zip
 from .compression import bzip2, lz4, lzip, lzma, lzo, xz
 from .filesystem import cramfs, fat, iso9660, squashfs, ubi
 
@@ -29,6 +29,8 @@ ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
         zip.ZIPHandler,
         dmg.DMGHandler,
         iso9660.ISO9660FSHandler,
+        stuffit.StuffItSITHandler,
+        stuffit.StuffIt5Handler,
     ),
     (
         bzip2.BZip2Handler,

--- a/unblob/handlers/archive/stuffit.py
+++ b/unblob/handlers/archive/stuffit.py
@@ -1,0 +1,91 @@
+"""
+We currently support detecting two specific Stuffit file formats:
+
+- Stuffit SIT (with 'SIT!' magic)
+- Stuffit 5 (with 'StuffIt (c)1997-' magic)
+
+Due to lack of access to sample files, source code, and really old packing tools,
+we don't support the following Stuffit file formats at the moment:
+
+- Stuffit X ('StuffIt!' or 'StuffIt?' magic)
+- Stuffit Delux ('SITD' magic)
+
+If you have the resources to add support for these archive formats,
+feel free to do so !
+"""
+import io
+from typing import List, Optional
+
+from structlog import get_logger
+
+from ...file_utils import Endian
+from ...models import StructHandler, ValidChunk
+
+logger = get_logger()
+
+
+class _StuffItHandlerBase(StructHandler):
+    """A common base for all StuffIt formats."""
+
+    def calculate_chunk(
+        self, file: io.BufferedIOBase, start_offset: int
+    ) -> Optional[ValidChunk]:
+
+        header = self.parse_header(file, endian=Endian.BIG)
+
+        return ValidChunk(
+            start_offset=start_offset,
+            end_offset=start_offset + header.archive_length,
+        )
+
+    @staticmethod
+    def make_extract_command(inpath: str, outdir: str) -> List[str]:
+        return ["unar", inpath, "-o", outdir]
+
+
+class StuffItSITHandler(_StuffItHandlerBase):
+    NAME = "stuffit"
+
+    YARA_RULE = r"""
+        strings:
+            // "SIT!\\x00", then 6 bytes (uint16 number of files and uint32 size), then "rLau".
+            $sit_magic = { 53 49 54 21 [6] 72 4C 61 75 }
+        condition:
+            $sit_magic
+    """
+
+    C_DEFINITIONS = r"""
+        struct sit_header
+        {
+            char signature[4];
+            uint16 num_files;
+            uint32 archive_length;
+            char signature2[4];
+        };
+    """
+    HEADER_STRUCT = "sit_header"
+
+
+class StuffIt5Handler(_StuffItHandlerBase):
+    NAME = "stuffit5"
+
+    YARA_RULE = r"""
+        strings:
+            // "StuffIt (c)1997-"
+            $stuffit5_magic = { 53 74 75 66 66 49 74 20 28 63 29 31 39 39 37 2D }
+        condition:
+            $stuffit5_magic
+    """
+
+    C_DEFINITIONS = r"""
+        struct stuffit5_header
+        {
+            char signature[80];
+            uint32 unknown;
+            uint32 archive_length;
+            uint32 entry_offset;
+            uint16 num_root_dir_entries;
+            uint32 first_entry_offset;
+        };
+    """
+    HEADER_STRUCT = "stuffit5_header"


### PR DESCRIPTION
We currently support detecting two specific Stuffit file formats:

- Stuffit SIT (with `SIT!` magic)
- Stuffit 5 (with `StuffIt (c)1997-` magic)

Due to lack of access to sample files, source code, and really old packing tools, we don't support the following Stuffit file formats at the moment:

- Stuffit X (`StuffIt!` or `StuffIt?` magic) - only partially supported by modern extractors
- Stuffit Delux (`SITD` magic) - only partially supported by modern extractors

Stuffit extraction is performed with the universal archiver (unar). Stuffit files have been created using Stuffit 2010 and Stuffit 5.5.

I think we should just merge this branch and stop losing time trying to reconstruct archives using tools that dates back to 1995 :)