### PR TITLE
Workflows: Run only on pushes to main and PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,13 @@
 name: Main
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+
 
 jobs:
   check_pre_commit:


### PR DESCRIPTION
There shouldn't be two workflow runs for a PR branch and the PR itself