### PR TITLE
Rename yara rule identifiers

### DIFF
--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -17,9 +17,9 @@ class TestHandler1(_BaseTestHandler):
     NAME = "handler1"
     YARA_RULE = r"""
         strings:
-            $magic = { 21 3C }
+            $handler1_magic = { 21 3C }
         condition:
-            $magic
+            $handler1_magic
     """
 
 
@@ -37,7 +37,7 @@ def test_make_yara_rules():
     rules = make_yara_rules(tuple([TestHandler1, TestHandler2]))
     matches = rules.match(data=b"!<        ustar")
     assert len(matches) == 2
-    assert matches[0].strings == [(0, "$magic", b"!<")]
+    assert matches[0].strings == [(0, "$handler1_magic", b"!<")]
     assert matches[1].strings == [(10, "$tar_magic", b"ustar")]
 
 
@@ -54,7 +54,7 @@ def test_search_yara_patterns(tmp_path: Path):
     result1, result2 = results
 
     assert result1.handler is handler1
-    assert result1.match.strings == [(0, "$magic", b"!<")]
+    assert result1.match.strings == [(0, "$handler1_magic", b"!<")]
 
     assert result2.handler is handler2
     assert result2.match.strings == [(10, "$tar_magic", b"ustar")]

--- a/unblob/handlers/archive/arj.py
+++ b/unblob/handlers/archive/arj.py
@@ -25,9 +25,9 @@ class ARJHandler(StructHandler):
 
     YARA_RULE = r"""
         strings:
-            $magic = { 60 EA [5] 0? [2] 0? } //
+            $arj_magic = { 60 EA [5] 0? [2] 0? }
         condition:
-            $magic
+            $arj_magic
     """
 
     # https://docs.fileformat.com/compression/arj/

--- a/unblob/handlers/archive/cab.py
+++ b/unblob/handlers/archive/cab.py
@@ -13,9 +13,9 @@ class CABHandler(StructHandler):
 
     YARA_RULE = r"""
         strings:
-            $magic = { 4D 53 43 46 00 00 00 00 } // MSCF, then reserved dword
+            $cab_magic = { 4D 53 43 46 00 00 00 00 } // MSCF, then reserved dword
         condition:
-            $magic
+            $cab_magic
     """
 
     C_DEFINITIONS = r"""

--- a/unblob/handlers/archive/dmg.py
+++ b/unblob/handlers/archive/dmg.py
@@ -15,9 +15,9 @@ class DMGHandler(StructHandler):
     YARA_RULE = r"""
         strings:
             // 'koly' magic, followed by version from 1 to 4, followed by fixed header size of 512
-            $magic = { 6b 6f 6c 79 00 00 00 04 00 00 02 00 }
+            $dmg_magic = { 6b 6f 6c 79 00 00 00 04 00 00 02 00 }
         condition:
-            $magic
+            $dmg_magic
     """
 
     C_DEFINITIONS = r"""

--- a/unblob/handlers/compression/bzip2.py
+++ b/unblob/handlers/compression/bzip2.py
@@ -25,9 +25,9 @@ class BZip2Handler(StructHandler):
     YARA_RULE = r"""
         strings:
             // magic + version + block_size + compressed_magic
-            $magic = /\x42\x5a\x68[\x31-\x39]\x31\x41\x59\x26\x53\x59/
+            $bzip2_magic = /\x42\x5a\x68[\x31-\x39]\x31\x41\x59\x26\x53\x59/
         condition:
-            $magic
+            $bzip2_magic
     """
 
     C_DEFINITIONS = r"""

--- a/unblob/handlers/filesystem/cramfs.py
+++ b/unblob/handlers/filesystem/cramfs.py
@@ -16,10 +16,10 @@ class CramFSHandler(StructHandler):
 
     YARA_RULE = r"""
         strings:
-            $magic_be = { 28 CD 3D 45 }
-            $magic_le = { 45 3D CD 28 }
+            $cramfs_magic_be = { 28 CD 3D 45 }
+            $cramfs_magic_le = { 45 3D CD 28 }
         condition:
-            $magic_le or $magic_be
+            $cramfs_magic_be or $cramfs_magic_le
     """
 
     C_DEFINITIONS = r"""


### PR DESCRIPTION
It makes it quite hard to debug C code when all the rules has the "$magic" identifier.