### PR TITLE
Add support for GZIP compression format.

### DIFF
--- a/tests/integration/compression/gzip/__input__/durian.dual.gz
+++ b/tests/integration/compression/gzip/__input__/durian.dual.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69e3ec6e917f22dfae50c4cc15a249d3cdfc0f0bccf972436db0733a641f1ddd
+size 86

--- a/tests/integration/compression/gzip/__input__/durian.eof.gz
+++ b/tests/integration/compression/gzip/__input__/durian.eof.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b78d065659afe2371a057bbabc0bca52158b4f67bf273c63a6382de664a56960
+size 59

--- a/tests/integration/compression/gzip/__input__/durian.gz
+++ b/tests/integration/compression/gzip/__input__/durian.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be0c9ca3ac8e90a5211663e6b8bce1f3c8ea102c349a0a36386e61ce543f9de4
+size 43

--- a/tests/integration/compression/gzip/__output__/durian.dual.gz_extract/0-43.gzip
+++ b/tests/integration/compression/gzip/__output__/durian.dual.gz_extract/0-43.gzip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be0c9ca3ac8e90a5211663e6b8bce1f3c8ea102c349a0a36386e61ce543f9de4
+size 43

--- a/tests/integration/compression/gzip/__output__/durian.dual.gz_extract/0-43.gzip_extract/durian1.txt
+++ b/tests/integration/compression/gzip/__output__/durian.dual.gz_extract/0-43.gzip_extract/durian1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f6c40480bb7cb03fb6162cdb247fd810d187dfd2c3967fa7b10c16f5fb93a17
+size 8

--- a/tests/integration/compression/gzip/__output__/durian.dual.gz_extract/43-86.gzip
+++ b/tests/integration/compression/gzip/__output__/durian.dual.gz_extract/43-86.gzip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be0c9ca3ac8e90a5211663e6b8bce1f3c8ea102c349a0a36386e61ce543f9de4
+size 43

--- a/tests/integration/compression/gzip/__output__/durian.dual.gz_extract/43-86.gzip_extract/durian1.txt
+++ b/tests/integration/compression/gzip/__output__/durian.dual.gz_extract/43-86.gzip_extract/durian1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f6c40480bb7cb03fb6162cdb247fd810d187dfd2c3967fa7b10c16f5fb93a17
+size 8

--- a/tests/integration/compression/gzip/__output__/durian.eof.gz_extract/0-43.gzip
+++ b/tests/integration/compression/gzip/__output__/durian.eof.gz_extract/0-43.gzip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be0c9ca3ac8e90a5211663e6b8bce1f3c8ea102c349a0a36386e61ce543f9de4
+size 43

--- a/tests/integration/compression/gzip/__output__/durian.eof.gz_extract/0-43.gzip_extract/durian1.txt
+++ b/tests/integration/compression/gzip/__output__/durian.eof.gz_extract/0-43.gzip_extract/durian1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f6c40480bb7cb03fb6162cdb247fd810d187dfd2c3967fa7b10c16f5fb93a17
+size 8

--- a/tests/integration/compression/gzip/__output__/durian.eof.gz_extract/43-59.unknown
+++ b/tests/integration/compression/gzip/__output__/durian.eof.gz_extract/43-59.unknown
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d067b9f32b027e9b7f620e6acf3895f46a4982e7b80abdff3b38e20df966a504
+size 16

--- a/tests/integration/compression/gzip/__output__/durian.gz_extract/0-43.gzip
+++ b/tests/integration/compression/gzip/__output__/durian.gz_extract/0-43.gzip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be0c9ca3ac8e90a5211663e6b8bce1f3c8ea102c349a0a36386e61ce543f9de4
+size 43

--- a/tests/integration/compression/gzip/__output__/durian.gz_extract/0-43.gzip_extract/durian1.txt
+++ b/tests/integration/compression/gzip/__output__/durian.gz_extract/0-43.gzip_extract/durian1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f6c40480bb7cb03fb6162cdb247fd810d187dfd2c3967fa7b10c16f5fb93a17
+size 8

--- a/unblob/handlers/__init__.py
+++ b/unblob/handlers/__init__.py
@@ -2,7 +2,7 @@ from typing import List, Tuple, Type
 
 from ..models import Handler
 from .archive import ar, arc, arj, cab, cpio, dmg, rar, sevenzip, stuffit, tar, zip
-from .compression import bzip2, compress, lz4, lzh, lzip, lzma, lzo, xz
+from .compression import bzip2, compress, gzip, lz4, lzh, lzip, lzma, lzo, xz
 from .filesystem import cramfs, extfs, fat, iso9660, jffs2, ntfs, squashfs, ubi
 
 ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
@@ -39,6 +39,7 @@ ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
     (
         bzip2.BZip2Handler,
         compress.UnixCompressHandler,
+        gzip.GZIPHandler,
         lzh.LZHHandler,
         lzip.LZipHandler,
         lzo.LZOHandler,

--- a/unblob/handlers/compression/_gzip_reader.py
+++ b/unblob/handlers/compression/_gzip_reader.py
@@ -1,0 +1,41 @@
+import gzip
+
+from ...file_utils import DEFAULT_BUFSIZE
+
+# pyright: reportGeneralTypeIssues=false
+
+
+class SingleMemberGzipReader(gzip._GzipReader):
+    def read_header(self):
+        self._init_read()
+        return self._read_gzip_header()
+
+    def read(self):
+        uncompress = b""
+
+        while True:
+            buf = self._fp.read(DEFAULT_BUFSIZE)
+
+            uncompress = self._decompressor.decompress(buf, DEFAULT_BUFSIZE)
+            self._fp.prepend(self._decompressor.unconsumed_tail)
+            self._fp.prepend(self._decompressor.unused_data)
+
+            if uncompress != b"":
+                break
+            if buf == b"":
+                raise EOFError(
+                    "Compressed file ended before the "
+                    "end-of-stream marker was reached"
+                )
+
+        self._add_read_data(uncompress)
+
+        return uncompress
+
+    def read_until_eof(self):
+        while not self._decompressor.eof:
+            self.read()
+
+    @property
+    def unused_data(self):
+        return self._decompressor.unused_data

--- a/unblob/handlers/compression/gzip.py
+++ b/unblob/handlers/compression/gzip.py
@@ -1,0 +1,99 @@
+"""
+Handler for gzip compression format based on standard documented
+at https://datatracker.ietf.org/doc/html/rfc1952.
+
+The handler will create valid chunks for each gzip compressed stream instead of
+concatenating sequential streams into an overall ValidChunk.
+
+We monkey patched Python builtin gzip's _GzipReader read() function to stop
+reading as soon as it reach the EOF marker of the current gzip stream. This
+is a requirement for unblob given that streams can be malformed and followed
+by garbage/random content that triggers BadGzipFile errors when gzip
+library tries to read the next stream header.
+"""
+import gzip
+import io
+from typing import List, Optional
+
+from structlog import get_logger
+
+from ...file_utils import DEFAULT_BUFSIZE, read_until_past
+from ...models import Handler, ValidChunk
+
+logger = get_logger()
+
+GZIP2_CRC_LEN = 4
+GZIP2_SIZE_LEN = 4
+GZIP2_FOOTER_LEN = GZIP2_CRC_LEN + GZIP2_SIZE_LEN
+
+
+class SingleMemberGzipReader(gzip._GzipReader):
+    def read(self):
+        uncompress = b""
+
+        while True:
+            buf = self._fp.read(DEFAULT_BUFSIZE)
+
+            uncompress = self._decompressor.decompress(buf, DEFAULT_BUFSIZE)
+            self._fp.prepend(self._decompressor.unconsumed_tail)
+            self._fp.prepend(self._decompressor.unused_data)
+
+            if uncompress != b"":
+                break
+            if buf == b"":
+                raise EOFError(
+                    "Compressed file ended before the "
+                    "end-of-stream marker was reached"
+                )
+
+        self._add_read_data(uncompress)
+        self._pos += len(uncompress)
+
+        return uncompress
+
+
+class GZIPHandler(Handler):
+    NAME = "gzip"
+
+    YARA_RULE = r"""
+    strings:
+        // id1 & id2
+        // compression method (0x8 = DEFLATE)
+        // flags, 00011111 (0x1f) is the highest since the first 3 bits are reserved
+        // unix time
+        // eXtra FLags
+        // Operating System (RFC1952 describes 0-13, or 255)
+        $gzip_magic = /\x1f\x8b\x08[\x00-\x1f][\x00-\xff]{4}[\x00-\x04][\x00-\x0c\xff]/
+    condition:
+        $gzip_magic
+    """
+
+    def calculate_chunk(
+        self, file: io.BufferedIOBase, start_offset: int
+    ) -> Optional[ValidChunk]:
+
+        fp = SingleMemberGzipReader(file)
+        fp._init_read()
+        if not fp._read_gzip_header():
+            return
+
+        try:
+            while not fp._decompressor.eof:
+                fp.read()
+        except gzip.BadGzipFile as e:
+            logger.warn(e)
+            return
+
+        file.seek(GZIP2_FOOTER_LEN - len(fp._decompressor.unused_data), io.SEEK_CUR)
+
+        # Gzip files can be padded with zeroes
+        end_offset = read_until_past(file, b"\x00")
+
+        return ValidChunk(
+            start_offset=start_offset,
+            end_offset=end_offset,
+        )
+
+    @staticmethod
+    def make_extract_command(inpath: str, outdir: str) -> List[str]:
+        return ["7z", "x", "-y", inpath, f"-o{outdir}"]


### PR DESCRIPTION
Handler for gzip compression format based on standard documented at https://datatracker.ietf.org/doc/html/rfc1952.

The handler will create valid chunks for each gzip compressed stream instead of concatenating sequential streams into an overall ValidChunk.

We monkey patched Python builtin gzip's _GzipReader read() function to stop reading as soon as it reach the EOF marker of the current gzip stream. This is a requirement for unblob given that streams can be malformed and followed by garbage/random content that triggers BadGzipFile errors when gzip library tries to read the next stream header.

Test files were generated using unix `gzip` tool:

```
gzip durian.txt
```

We created two other test files: one with two sequential gzip streams, and another with a gzip stream followed by random content.