### PR TITLE
Remove the sharp edges around the Rust module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,15 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
 
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: 1.57.0
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v1
+
       - name: Check pre-commit hook
         uses: pre-commit/action@v2.0.3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
 
-      - name: Setup python
+      - name: Setup Python
         uses: actions/setup-python@v2
 
       - name: Setup Rust

--- a/.github/workflows/rust-binding.yml
+++ b/.github/workflows/rust-binding.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
 
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: 1.57.0
+
       - name: Setup cache
         uses: Swatinem/rust-cache@v1
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ $ sudo apt install git-lfs
 $ git lfs install
 ```
 
+If you have cloned the repository prior to installing Git LFS, you
+need to run the following commands once:
+
+```console
+$ git lfs pull
+$ git lfs checkout
+```
+
 After you installed Git LFS, you can run all tests, with
 `python -m pytest tests/` in the activated virtualenv.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ We are using [poetry](https://python-poetry.org/) for managing dependencies.
 
 `poetry install` will install all required dependencies in a virtualenv.
 
+### Rust extension module (optional)
+
+Unblob has an optional Rust extension for performance intensive
+processing. Building it is entirely optional and requires
+`[rustup](https://rustup.rs/)` to be installed on the host system. Run
+`UNBLOB_BUILD_RUST_EXTENSION=1 poetry install` to build and install
+the extension. Set `RUST_DEBUG=1` to build it in debug mode.
+
 ### Testing
 
 We are using pytest for running our test suite.\

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.57.0"
+profile = "default"

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1,11 +1,26 @@
 import pytest
 from pytest import approx
 
-import unblob._py
-import unblob._rust
+import unblob._py as python_binding
+
+try:
+    import unblob._rust as rust_binding
+except ModuleNotFoundError:
+    rust_binding = None
 
 
-@pytest.fixture(params=[unblob._rust, unblob._py])
+@pytest.fixture(
+    params=[
+        pytest.param(python_binding, id="Python"),
+        pytest.param(
+            rust_binding,
+            id="Rust",
+            marks=pytest.mark.skipif(
+                rust_binding is None, reason="Rust binding is not present"
+            ),
+        ),
+    ]
+)
 def binding(request):
     yield request.param
 


### PR DESCRIPTION
* Set required Rust toolchain version so that `rustup` would forced to use the correct version 
* Mentioned installation procedure in the README, mentioning that you need to have `rustup` installed
* Made Python tests of it optional, and they will be skipped if the extension module is unavailable
