### PR TITLE
tar: support smaller than RECORDSIZE archives without 2x zero blocks

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -129,6 +129,19 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "lark"
+version = "1.0.0"
+description = "a modern parsing library"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.extras]
+atomic_cache = ["atomicwrites"]
+nearley = ["js2py"]
+regex = ["regex"]
+
+[[package]]
 name = "nodeenv"
 version = "1.6.0"
 description = "Node.js virtual environment builder"
@@ -381,7 +394,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c20d5ac77feced16d39a845109f40aab9ff75b0f1adcccb70f672a7dc954e5d2"
+content-hash = "b3663d45d1926a5a2239856d84088fd0ef130d410da2d43ce01afbf0576fec83"
 
 [metadata.files]
 arpy = [
@@ -479,6 +492,10 @@ identify = [
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+lark = [
+    {file = "lark-1.0.0-py2.py3-none-any.whl", hash = "sha256:10818563b44e18ea264b5013a80fe04406999ad51bacc74214f69f13d95af6e1"},
+    {file = "lark-1.0.0.tar.gz", hash = "sha256:2269dee215e6c689d5ce9d34fdc6e749d0c1c763add3fc7935938ebd7da159cb"},
 ]
 nodeenv = [
     {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ ubi-reader = "^0.7.0"
 python-lzo = "^1.12"
 
 [tool.poetry.dev-dependencies]
+lark = "^1.0.0"
 pytest = "^6.2.4"
 pyright = "^0.0.12"
 pre-commit = "^2.15.0"

--- a/tests/handlers/archive/test_tar.py
+++ b/tests/handlers/archive/test_tar.py
@@ -1,0 +1,58 @@
+import io
+
+import pytest
+from helpers import unhex
+
+from unblob.handlers.archive.tar import _get_tar_end_offset
+
+TAR_BLOCK = unhex(
+    """\
+00000000  74 65 73 74 2f 66 6f 6f  2e 64 61 74 00 00 00 00  |test/foo.dat....|
+00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
+*
+00000060  00 00 00 00 30 30 30 30  36 34 34 00 30 30 30 31  |....0000644.0001|
+00000070  37 35 30 00 30 30 30 30  31 34 34 00 30 30 30 30  |750.0000144.0000|
+00000080  30 30 30 30 32 30 30 00  31 34 31 36 30 30 35 35  |0000200.14160055|
+00000090  37 32 35 00 30 31 30 32  32 33 00 20 30 00 00 00  |725.010223. 0...|
+000000a0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
+*
+00000100  00 75 73 74 61 72 20 20  00 00 00 00 00 00 00 00  |.ustar  ........|
+00000110  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
+*
+00000200  c4 d8 da 39 27 3e 70 1b  ec 79 fc 36 d7 e4 4e 58  |...9'>p..y.6..NX|
+00000210  e7 ef 90 0d 83 26 a9 f6  71 a2 42 b0 19 43 d3 ea  |.....&..q.B..C..|
+00000220  29 48 38 39 cd a0 e9 ad  38 1e 53 3f 60 4d e1 2a  |)H89....8.S?`M.*|
+00000230  de 8b ca f8 64 66 c1 0d  5e 4c aa fa cc c5 ab 73  |....df..^L.....s|
+00000240  1d 2d ec f1 1b 5f aa 4a  b4 c7 94 95 00 60 3a a3  |.-..._.J.....`:.|
+00000250  42 d9 45 2c d8 b1 99 11  da f7 33 34 7d 21 2f d4  |B.E,......34}!/.|
+00000260  b3 f6 cd c6 62 80 d1 39  0c 47 c1 fe 30 15 42 39  |....b..9.G..0.B9|
+00000270  7b fd 92 94 f7 fe 90 94  77 97 8c 76 61 e7 2c 13  |{.......w..va.,.|
+00000280  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
+*
+00000400  # Padded to 2*512 byte blocks
+"""
+)
+
+PADDED_TO_DEFAULT_BLOCKING_FACTOR = unhex(
+    """\
+00000400  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
+*
+00002800"""
+)
+
+
+@pytest.mark.parametrize(
+    "contents",
+    (
+        pytest.param(
+            TAR_BLOCK + PADDED_TO_DEFAULT_BLOCKING_FACTOR,
+            id="padded-to-default-blocking-factor",
+        ),
+        pytest.param(TAR_BLOCK, id="not-padded"),
+    ),
+)
+def test_offset(contents: bytes):
+    f = io.BytesIO(contents)
+
+    offset = _get_tar_end_offset(f)
+    assert offset == len(contents)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,111 @@
+import binascii
+import io
+
+from attr import dataclass
+from lark import Lark, Transformer
+from lark.visitors import Discard
+
+
+def unhex(hexdump: str) -> bytes:
+    """Unparses hexdump back to binary representation.
+
+    In addition to basic parsing the following extra features are supported:
+
+    * line comments starting with ``#``
+    * squeezing (repetition of previous line) indicated via ``*`` (see: man 1 hexdump)
+
+    Relative position of data is kept in the result object. This means
+    that the offset indicator at the beginning of each line is
+    significant, each line will be stored at the position indicated
+    relative to the start position.
+
+    The printable ASCII column is discarded during parsing.
+    """
+    parsed = _hexdump_parser.parse(hexdump)
+    return _HexDumpToBin().transform(parsed)
+
+
+_hexdump_parser = Lark(
+    """
+    COMMENT:    _SPACE* "#" /[^\n]/x* NEWLINE
+    %ignore COMMENT
+
+    %import common.NEWLINE
+    %import common.HEXDIGIT
+
+    start:   line (_NEWLINE line)* _NEWLINE?
+    line:    address [_SEPARATOR hex _SEPARATOR "|"? ascii "|"?]  -> canonical
+             | SQUEEZE                                            -> squeezed
+    address: HEXDIGIT+                                            -> join
+    hex:     HEXDIGIT+ (_SPACE* HEXDIGIT)+                        -> join
+    ascii:   CHAR+                                                -> join
+    CHAR:    /./
+    SQUEEZE: "*"
+
+    _SEPARATOR: ": " | "  "
+    _SPACE:     " "
+    _NEWLINE:   NEWLINE
+"""
+)
+
+
+@dataclass
+class _HexdumpLine:
+    offset: int
+    data: bytes
+
+    @classmethod
+    def from_bytes(cls, offset, data):
+        offset = int.from_bytes(binascii.unhexlify(offset), byteorder="big")
+        data = binascii.unhexlify(data) if data else b""
+        return cls(offset, data)
+
+    def __len__(self):
+        return len(self.data)
+
+
+class _HexDumpToBin(Transformer):
+    def __init__(self):
+        super().__init__(visit_tokens=False)
+        self._last_line = None
+        self._squeezing = False
+
+    def join(self, s):
+        return "".join(s.strip() for s in s)
+
+    def canonical(self, s):
+        line = _HexdumpLine.from_bytes(s[0], s[1])
+        if self._squeezing:
+            self._squeezing = False
+            line = self._squeeze_in_data(line)
+        self._last_line = line
+        return self._last_line
+
+    def _squeeze_in_data(self, line: _HexdumpLine) -> _HexdumpLine:
+        if not self._last_line:
+            raise ValueError("Squeezed line cannot be the first line in a hexdump")
+
+        delta = line.offset - (self._last_line.offset + len(self._last_line))
+        count = delta // len(self._last_line)
+
+        return _HexdumpLine(
+            self._last_line.offset + len(self._last_line),
+            self._last_line.data * count + line.data,
+        )
+
+    def squeezed(self, _s):
+        self._squeezing = True
+        return Discard
+
+    def trailing(self, s):
+        print(s)
+        return _HexdumpLine(
+            int.from_bytes(binascii.unhexlify(s[0]), byteorder="big"), b""
+        )
+
+    def start(self, s):
+        rv = io.BytesIO()
+        for line in s:
+            rv.write(line.data)
+
+        return rv.getvalue()

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -17,8 +17,23 @@ from unblob.file_utils import (
     get_endian,
     iterate_file,
     iterate_patterns,
+    round_down,
     round_up,
 )
+
+
+@pytest.mark.parametrize(
+    "size, alignment, result",
+    (
+        (0, 5, 0),
+        (1, 10, 0),
+        (12, 10, 10),
+        (29, 10, 20),
+        (1, 512, 0),
+    ),
+)
+def test_round_down(size, alignment, result):
+    assert round_down(size, alignment) == result
 
 
 @pytest.mark.parametrize(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,63 @@
+import pytest
+from helpers import unhex
+
+EMACS_VIM = """\
+00000000: 0102 0304 0506 0708 090a 0b0c 0d0e 0f10  ................
+00000010: 4142 4344 4546 4748 494a 4b4c 4d4e 4f44  ABCDEFGHIJKLMNOD
+"""
+
+HEXDUMP_C = """\
+00000000  01 02 03 04 05 06 07 08  09 0a 0b 0c 0d 0e 0f 10  |................|
+00000010  41 42 43 44 45 46 47 48  49 4a 4b 4c 4d 4e 4f 44  |ABCDEFGHIJKLMNOD|
+00000020
+"""
+
+WITH_COMMENTS = """\
+# Comments are supported
+00000000  01 02 03 04 05 06 07 08  09 0a 0b 0c 0d 0e 0f 10  |................|
+00000010  41 42 43 44 45 46 47 48  49 4a 4b 4c 4d 4e 4f 44  |ABCDEFGHIJKLMNOD|  # even at the end of lines
+00000020  # also at the last line
+"""
+
+EXPECTED = b"\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10ABCDEFGHIJKLMNOD"
+
+
+@pytest.mark.parametrize(
+    "hexdump",
+    (
+        pytest.param(EMACS_VIM, id="Vim-Emacs"),
+        pytest.param(HEXDUMP_C, id="hexdump-C"),
+        pytest.param(WITH_COMMENTS, id="with-comments"),
+    ),
+)
+def test_hexdump(hexdump):
+    binary = unhex(hexdump)
+    assert binary == EXPECTED
+
+
+WITH_SQUEEZED_DATA = """\
+00: 0102 0304 0506 0708 090a 0b0c 0d0e 0f10  ................
+10: FF00 FF00 FF00 FF00 FF00 FF00 FF00 FF00  ................
+*
+30: 4142 4344 4546 4748 494a 4b4c 4d4e 4f44  ABCDEFGHIJKLMNOD
+"""
+
+
+def test_with_squized_data():
+    binary = unhex(WITH_SQUEEZED_DATA)
+    assert binary[:0x10] == EXPECTED[:0x10]
+    assert binary[0x10:0x30] == b"\xFF\x00" * 0x10
+    assert binary[0x30:] == EXPECTED[0x10:]
+
+
+WITH_SQUEEZED_END = """\
+00: FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF  ................
+*
+40
+"""
+
+
+def test_with_squized_end():
+    binary = unhex(WITH_SQUEEZED_END)
+    assert len(binary) == 0x40
+    assert binary == b"\xFF" * 0x40

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -31,6 +31,11 @@ def snull(content: bytes):
     return content.rstrip(b"\x00")
 
 
+def round_down(size: int, alignment: int):
+    """Round down size to the alignment boundary."""
+    return alignment * math.floor(size / alignment)
+
+
 def round_up(size: int, alignment: int):
     """Round up size to the alignment boundary."""
     return alignment * math.ceil(size / alignment)

--- a/unblob/handlers/archive/tar.py
+++ b/unblob/handlers/archive/tar.py
@@ -16,23 +16,35 @@ MAGIC_OFFSET = 257
 
 
 def _get_tar_end_offset(file: io.BufferedIOBase):
+    # First find the end of the last entry in the file
+    last_offset = _get_end_of_last_tar_entry(file)
+
+    # Then find where the final zero blocks end
+    return _find_end_of_padding(file, find_from=last_offset)
+
+
+def _get_end_of_last_tar_entry(file: io.BufferedIOBase) -> int:
     tf = tarfile.TarFile(mode="r", fileobj=file)
     last_member = tf.getmembers()[-1]
     last_file_size = BLOCK_SIZE * (1 + (last_member.size // BLOCK_SIZE))
-    last_offset = last_member.offset + HEADER_SIZE + last_file_size
-    padded_end_offset = round_up(last_offset, tarfile.RECORDSIZE)
+    return last_member.offset + HEADER_SIZE + last_file_size
 
-    file.seek(last_offset)
-    padding_len = padded_end_offset - last_offset
+
+def _find_end_of_padding(file: io.BufferedIOBase, *, find_from: int) -> int:
+    file.seek(find_from)
+    find_to = round_up(find_from, tarfile.RECORDSIZE)
+    padding_len = find_to - find_from
     padding = file.read(padding_len)
 
-    first_nonzero = len(padding)
-    for i, b in enumerate(padding):
+    first_nonzero = find_from + len(padding)
+    for i, b in enumerate(padding, find_from):
         if b != 0:
             first_nonzero = i
             break
 
-    return round_down(last_offset + first_nonzero, BLOCK_SIZE)
+    # if the first nonzero would be inside a possible next chunk, we
+    # round it down
+    return round_down(first_nonzero, BLOCK_SIZE)
 
 
 class TarHandler(StructHandler):


### PR DESCRIPTION
There are tar files (such as what found in #118) which are not padded
to `20*BLOCKSIZE` bytes and doesn't have `2*BLOCKSIZE` ending
zeros.

The above cases are independent:

1. `tarfile.RECORDSIZE` is just tarfile.BLOCKSIZE times what GNU tar
calls as `--blocking-factor`. It's default value is 20 matching the
Python implementation, but it is not something we should expect to be
used and certainly. It can be smaller and even greater albeit it is
discouraged to increase it from the default.

2. According to `info tar` extractors shouldn't rely on the
existence of ending zero blocks:

> At the end of the archive file there are two 512-byte blocks filled
> with binary zeros as an end-of-file marker. A reasonable system
> should write such end-of-file marker at the end of an archive, but
> must not assume that such a block exists when reading an archive. In
> particular GNU 'tar' always issues a warning if it does not
> encounter it.

In reality GNU tar doesn't warn when a file without 2 zero blocks is
extracted.

