### PR TITLE
lzma: Fix infinite loop if file end is reached

### DIFF
--- a/unblob/handlers/compression/lzma.py
+++ b/unblob/handlers/compression/lzma.py
@@ -27,8 +27,10 @@ class LZMAHandler(Handler):
         decompressor = lzma.LZMADecompressor(format=lzma.FORMAT_ALONE)
 
         try:
-            while not decompressor.eof:
-                decompressor.decompress(file.read(DEFAULT_BUFSIZE))
+            data = file.read(DEFAULT_BUFSIZE)
+            while data and not decompressor.eof:
+                decompressor.decompress(data)
+                data = file.read(DEFAULT_BUFSIZE)
         except lzma.LZMAError:
             return
 


### PR DESCRIPTION
`decompressor.eof` is set when the compressed stream ends not when the
underlying file.