### PR TITLE
Add support for JFFS2 filesystem format.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -82,6 +82,14 @@ tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
 toml = ["tomli"]
 
 [[package]]
+name = "cstruct"
+version = "2.1"
+description = "C-style structs for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "dissect.cstruct"
 version = "2.0"
 description = "Structure parsing in Python made easy."
@@ -127,6 +135,21 @@ description = "iniconfig: brain-dead simple config-ini parsing"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "jefferson"
+version = "0.3"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+develop = false
+
+[package.source]
+type = "git"
+url = "https://github.com/IoT-Inspector/jefferson.git"
+reference = "216eee6c56d338e5a14a0af5d07f1117cff92b3b"
+resolved_reference = "216eee6c56d338e5a14a0af5d07f1117cff92b3b"
 
 [[package]]
 name = "lark"
@@ -394,7 +417,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "b3663d45d1926a5a2239856d84088fd0ef130d410da2d43ce01afbf0576fec83"
+content-hash = "4ce7fb75dd8eacb9ff7d9fa4855310fe538fdb4973f994cfa639660986c4f2bd"
 
 [metadata.files]
 arpy = [
@@ -473,6 +496,10 @@ coverage = [
     {file = "coverage-6.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de"},
     {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
 ]
+cstruct = [
+    {file = "cstruct-2.1-py2.py3-none-any.whl", hash = "sha256:ed4449bc672a37abbc0ecfbdaf4c26aa6ab1bafe7dfdb83eab2953cdbb153cf4"},
+    {file = "cstruct-2.1.tar.gz", hash = "sha256:9c2741f46fb12613a4f746369ec0a7b3b1f25712178c567437902d446f7c3648"},
+]
 "dissect.cstruct" = [
     {file = "dissect.cstruct-2.0-py3-none-any.whl", hash = "sha256:e150abcc7500a279126ebf1a0f87c34d857e126ac3d65a980844bfb3296a5492"},
     {file = "dissect.cstruct-2.0.tar.gz", hash = "sha256:4f1d3911da99270213feed0a0b22e70670b04fe53b16d95d2e04bafcd338f547"},
@@ -493,6 +520,7 @@ iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
+jefferson = []
 lark = [
     {file = "lark-1.0.0-py2.py3-none-any.whl", hash = "sha256:10818563b44e18ea264b5013a80fe04406999ad51bacc74214f69f13d95af6e1"},
     {file = "lark-1.0.0.tar.gz", hash = "sha256:2269dee215e6c689d5ce9d34fdc6e749d0c1c763add3fc7935938ebd7da159cb"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ arpy = "^2.2.0"
 rarfile = "^4.0"
 ubi-reader = "^0.7.0"
 python-lzo = "^1.12"
+cstruct = "2.1"
+jefferson = { git = "https://github.com/IoT-Inspector/jefferson.git", rev = "216eee6c56d338e5a14a0af5d07f1117cff92b3b" }
+
 
 [tool.poetry.dev-dependencies]
 lark = "^1.0.0"

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.lzo.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.lzo.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bcb08d0b067c9bd86b8e3836858af5e3ef7047b6b13420739b6e23a48150de2
+size 400

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.lzo.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.lzo.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:933f971afbb838c6b4eac967829b900ad06c77ad52e1e5d4c22d3f4dfef908ec
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.nocomp.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.nocomp.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6f55d6425951df98b183f0352ccace3a6b63fc7e34bd913bb522507d4e0e87d
+size 416

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.nocomp.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.nocomp.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ed98c9e2183f06cf74ae9bc3226c5c73dc8fa4a50ce23e3ded8bba7cb9a0fcd
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.rtime.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.rtime.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a7fc72cf2264c33fe5297d5d2d2246e346705e50b711ebf54a03b62a9e28e14
+size 392

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.rtime.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.rtime.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:995de45ee0823e3121eca4310f1938b8cf4db315f267d8af6efc940f7dc58ba8
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.zlib.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.zlib.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6a4da9831a5ab98e03f81d829793e3119eb3a3ffb05227b4b98bc604cc7f3dc
+size 484

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.zlib.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.be.zlib.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dfbb9d9f3cae2d3f81a7064a65b9f6d018963af0a46cf1aa2e84dd0c7aa2c7c
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.lzo.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.lzo.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fbb0c52d2b6b37c491bdd9c708eb4872d5cc0568eeed91bfdf9b1491a486bdd
+size 400

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.lzo.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.lzo.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ab8976689fc2f1140f576c6371ec27ead1a8d014906aa8e91ddd6d0b48f9864
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.nocomp.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.nocomp.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:774b980c212ce26c8abb63dece066480334d430daf2957ebfd35250e5f436e08
+size 416

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.nocomp.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.nocomp.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fc7aa0aa8041098371454c3159d19808289cda3e7426cd07f8fb1e9b7e21e5d
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.rtime.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.rtime.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16ef9cb45826fe1c5a2fc13627c321b606342b94cce05a7a02fe5fd4ef175646
+size 392

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.rtime.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.rtime.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c46076c550ef7567dc01ffa412b98cd78e1940466a1b252b33b21ed1f7e3ec47
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.zlib.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.zlib.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c1f77e27694761fa6e8e1264318792db43314f1af9d5e3f14f88e862eece44e
+size 484

--- a/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.zlib.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__input__/fruits.new.le.zlib.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08cceee3614d27227e19ccfe1b7f0b6abf1731d87fd3dc5ce7e2c7051a9621c1
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.jffs2_extract/0-400.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.jffs2_extract/0-400.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bcb08d0b067c9bd86b8e3836858af5e3ef7047b6b13420739b6e23a48150de2
+size 400

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.jffs2_extract/0-400.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.jffs2_extract/0-400.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bd0000d123b9a50c574b322492fe55e1ddec5117423379349e7fb36bcd594b2
+size 9

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.jffs2_extract/0-400.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.jffs2_extract/0-400.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.jffs2_extract/0-400.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.jffs2_extract/0-400.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.padded.jffs2_extract/0-65536.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.padded.jffs2_extract/0-65536.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:933f971afbb838c6b4eac967829b900ad06c77ad52e1e5d4c22d3f4dfef908ec
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bd0000d123b9a50c574b322492fe55e1ddec5117423379349e7fb36bcd594b2
+size 9

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.lzo.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.jffs2_extract/0-416.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.jffs2_extract/0-416.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6f55d6425951df98b183f0352ccace3a6b63fc7e34bd913bb522507d4e0e87d
+size 416

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.jffs2_extract/0-416.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.jffs2_extract/0-416.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.jffs2_extract/0-416.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.jffs2_extract/0-416.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.jffs2_extract/0-416.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.jffs2_extract/0-416.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.padded.jffs2_extract/0-65536.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.padded.jffs2_extract/0-65536.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ed98c9e2183f06cf74ae9bc3226c5c73dc8fa4a50ce23e3ded8bba7cb9a0fcd
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.nocomp.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.jffs2_extract/0-392.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.jffs2_extract/0-392.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a7fc72cf2264c33fe5297d5d2d2246e346705e50b711ebf54a03b62a9e28e14
+size 392

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.jffs2_extract/0-392.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.jffs2_extract/0-392.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.jffs2_extract/0-392.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.jffs2_extract/0-392.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.jffs2_extract/0-392.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.jffs2_extract/0-392.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.padded.jffs2_extract/0-65536.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.padded.jffs2_extract/0-65536.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:995de45ee0823e3121eca4310f1938b8cf4db315f267d8af6efc940f7dc58ba8
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.rtime.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.jffs2_extract/0-484.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.jffs2_extract/0-484.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6a4da9831a5ab98e03f81d829793e3119eb3a3ffb05227b4b98bc604cc7f3dc
+size 484

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.jffs2_extract/0-484.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.jffs2_extract/0-484.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.jffs2_extract/0-484.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.jffs2_extract/0-484.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.jffs2_extract/0-484.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.jffs2_extract/0-484.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.padded.jffs2_extract/0-65536.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.padded.jffs2_extract/0-65536.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dfbb9d9f3cae2d3f81a7064a65b9f6d018963af0a46cf1aa2e84dd0c7aa2c7c
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.be.zlib.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.jffs2_extract/0-400.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.jffs2_extract/0-400.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fbb0c52d2b6b37c491bdd9c708eb4872d5cc0568eeed91bfdf9b1491a486bdd
+size 400

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.jffs2_extract/0-400.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.jffs2_extract/0-400.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bd0000d123b9a50c574b322492fe55e1ddec5117423379349e7fb36bcd594b2
+size 9

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.jffs2_extract/0-400.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.jffs2_extract/0-400.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.jffs2_extract/0-400.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.jffs2_extract/0-400.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.padded.jffs2_extract/0-65536.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.padded.jffs2_extract/0-65536.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ab8976689fc2f1140f576c6371ec27ead1a8d014906aa8e91ddd6d0b48f9864
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bd0000d123b9a50c574b322492fe55e1ddec5117423379349e7fb36bcd594b2
+size 9

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.lzo.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.jffs2_extract/0-416.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.jffs2_extract/0-416.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:774b980c212ce26c8abb63dece066480334d430daf2957ebfd35250e5f436e08
+size 416

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.jffs2_extract/0-416.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.jffs2_extract/0-416.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.jffs2_extract/0-416.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.jffs2_extract/0-416.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.jffs2_extract/0-416.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.jffs2_extract/0-416.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.padded.jffs2_extract/0-65536.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.padded.jffs2_extract/0-65536.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fc7aa0aa8041098371454c3159d19808289cda3e7426cd07f8fb1e9b7e21e5d
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.nocomp.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.jffs2_extract/0-392.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.jffs2_extract/0-392.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16ef9cb45826fe1c5a2fc13627c321b606342b94cce05a7a02fe5fd4ef175646
+size 392

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.jffs2_extract/0-392.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.jffs2_extract/0-392.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.jffs2_extract/0-392.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.jffs2_extract/0-392.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.jffs2_extract/0-392.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.jffs2_extract/0-392.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.padded.jffs2_extract/0-65536.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.padded.jffs2_extract/0-65536.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c46076c550ef7567dc01ffa412b98cd78e1940466a1b252b33b21ed1f7e3ec47
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.rtime.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.jffs2_extract/0-484.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.jffs2_extract/0-484.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c1f77e27694761fa6e8e1264318792db43314f1af9d5e3f14f88e862eece44e
+size 484

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.jffs2_extract/0-484.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.jffs2_extract/0-484.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.jffs2_extract/0-484.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.jffs2_extract/0-484.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.jffs2_extract/0-484.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.jffs2_extract/0-484.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.padded.jffs2_extract/0-65536.jffs2_new
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.padded.jffs2_extract/0-65536.jffs2_new
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08cceee3614d27227e19ccfe1b7f0b6abf1731d87fd3dc5ce7e2c7051a9621c1
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_new/__output__/fruits.new.le.zlib.padded.jffs2_extract/0-65536.jffs2_new_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.lzo.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.lzo.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63c9508ba3e12cf17aeba103503219f169d85ffffa9e857b2ab75cac1f50f7c7
+size 400

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.lzo.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.lzo.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2990007afc9f25cf921049bacb270299a90924ec2f099f7590449db0ad55b4a6
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.nocomp.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.nocomp.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df20f5f7d7514b1e589e214ca34e9ed6ba67e7057d0177c3bf76881cdd9b9ac4
+size 416

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.nocomp.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.nocomp.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72d8e15ba41457c90fa4eb8dc6364106fdf8308b344eb8c187555569a2ebe1c5
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.rtime.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.rtime.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a06e24175d7fefb27fdcb0f1d128d7d2ba85730f15c6ca156e67b071899e4c4e
+size 392

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.rtime.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.rtime.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7f486ea423eabc1c7a7405e89aeab04357d97a88bb3d541fe3a18c43698e7a5
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.zlib.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.zlib.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:528445f72ef3d8d3fec86c47b15ea59b7962ed276cef4cb472b29bfdfdb1a997
+size 484

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.zlib.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.be.zlib.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4f0937a3297e6821a8e982b86842df54d41ee475fbd051d4faef1c695ffd7b4
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.lzo.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.lzo.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37b8c26ba08848f8f4c39550578f19c62b9da7a0bd026c8d0ac4cafa198ac1a9
+size 400

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.lzo.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.lzo.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a935d9394038576115b771a91c1711f0da55d1e47ee1e2a8ee4ff38b8343dbe4
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.nocomp.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.nocomp.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6e000b9e834c476b1ccd6f0cacfdb7f1b4f637b4b0ae4c4faca6e77fc037402
+size 416

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.nocomp.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.nocomp.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2b833f05e67d78e36d5a448c28dafb23a5e009584f105f39b7d5a8aed287a9f
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.rtime.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.rtime.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e2fd74855cd80a93926d9a77287ce15cc356fc10fe4231f04c2988ea3429104
+size 392

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.rtime.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.rtime.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd6b783078b0b1e6d584dec198b3ed38d787f43cfca9e97deedaed3276d02b08
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.zlib.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.zlib.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a52e17d5735fc785f14c9015cb48e3102bb23a220e9646c9c577bd01bcd5c321
+size 484

--- a/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.zlib.padded.jffs2
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__input__/fruits.old.le.zlib.padded.jffs2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e967993964882a32ed168428ad30442c037f1a9e79ed8bb6a84a583a6c5593e
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.jffs2_extract/0-400.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.jffs2_extract/0-400.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63c9508ba3e12cf17aeba103503219f169d85ffffa9e857b2ab75cac1f50f7c7
+size 400

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.jffs2_extract/0-400.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.jffs2_extract/0-400.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bd0000d123b9a50c574b322492fe55e1ddec5117423379349e7fb36bcd594b2
+size 9

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.jffs2_extract/0-400.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.jffs2_extract/0-400.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.jffs2_extract/0-400.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.jffs2_extract/0-400.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.padded.jffs2_extract/0-65536.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.padded.jffs2_extract/0-65536.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2990007afc9f25cf921049bacb270299a90924ec2f099f7590449db0ad55b4a6
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bd0000d123b9a50c574b322492fe55e1ddec5117423379349e7fb36bcd594b2
+size 9

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.lzo.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.jffs2_extract/0-416.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.jffs2_extract/0-416.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df20f5f7d7514b1e589e214ca34e9ed6ba67e7057d0177c3bf76881cdd9b9ac4
+size 416

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.jffs2_extract/0-416.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.jffs2_extract/0-416.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.jffs2_extract/0-416.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.jffs2_extract/0-416.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.jffs2_extract/0-416.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.jffs2_extract/0-416.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.padded.jffs2_extract/0-65536.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.padded.jffs2_extract/0-65536.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72d8e15ba41457c90fa4eb8dc6364106fdf8308b344eb8c187555569a2ebe1c5
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.nocomp.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.jffs2_extract/0-392.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.jffs2_extract/0-392.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a06e24175d7fefb27fdcb0f1d128d7d2ba85730f15c6ca156e67b071899e4c4e
+size 392

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.jffs2_extract/0-392.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.jffs2_extract/0-392.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.jffs2_extract/0-392.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.jffs2_extract/0-392.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.jffs2_extract/0-392.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.jffs2_extract/0-392.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.padded.jffs2_extract/0-65536.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.padded.jffs2_extract/0-65536.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7f486ea423eabc1c7a7405e89aeab04357d97a88bb3d541fe3a18c43698e7a5
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.rtime.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.jffs2_extract/0-484.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.jffs2_extract/0-484.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:528445f72ef3d8d3fec86c47b15ea59b7962ed276cef4cb472b29bfdfdb1a997
+size 484

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.jffs2_extract/0-484.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.jffs2_extract/0-484.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.jffs2_extract/0-484.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.jffs2_extract/0-484.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.jffs2_extract/0-484.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.jffs2_extract/0-484.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.padded.jffs2_extract/0-65536.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.padded.jffs2_extract/0-65536.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4f0937a3297e6821a8e982b86842df54d41ee475fbd051d4faef1c695ffd7b4
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.be.zlib.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.jffs2_extract/0-400.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.jffs2_extract/0-400.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37b8c26ba08848f8f4c39550578f19c62b9da7a0bd026c8d0ac4cafa198ac1a9
+size 400

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.jffs2_extract/0-400.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.jffs2_extract/0-400.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bd0000d123b9a50c574b322492fe55e1ddec5117423379349e7fb36bcd594b2
+size 9

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.jffs2_extract/0-400.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.jffs2_extract/0-400.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.jffs2_extract/0-400.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.jffs2_extract/0-400.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.padded.jffs2_extract/0-65536.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.padded.jffs2_extract/0-65536.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a935d9394038576115b771a91c1711f0da55d1e47ee1e2a8ee4ff38b8343dbe4
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bd0000d123b9a50c574b322492fe55e1ddec5117423379349e7fb36bcd594b2
+size 9

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.lzo.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.jffs2_extract/0-416.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.jffs2_extract/0-416.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6e000b9e834c476b1ccd6f0cacfdb7f1b4f637b4b0ae4c4faca6e77fc037402
+size 416

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.jffs2_extract/0-416.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.jffs2_extract/0-416.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.jffs2_extract/0-416.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.jffs2_extract/0-416.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.jffs2_extract/0-416.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.jffs2_extract/0-416.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.padded.jffs2_extract/0-65536.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.padded.jffs2_extract/0-65536.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2b833f05e67d78e36d5a448c28dafb23a5e009584f105f39b7d5a8aed287a9f
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.nocomp.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.jffs2_extract/0-392.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.jffs2_extract/0-392.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e2fd74855cd80a93926d9a77287ce15cc356fc10fe4231f04c2988ea3429104
+size 392

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.jffs2_extract/0-392.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.jffs2_extract/0-392.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.jffs2_extract/0-392.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.jffs2_extract/0-392.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.jffs2_extract/0-392.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.jffs2_extract/0-392.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.padded.jffs2_extract/0-65536.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.padded.jffs2_extract/0-65536.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd6b783078b0b1e6d584dec198b3ed38d787f43cfca9e97deedaed3276d02b08
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.rtime.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.jffs2_extract/0-484.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.jffs2_extract/0-484.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a52e17d5735fc785f14c9015cb48e3102bb23a220e9646c9c577bd01bcd5c321
+size 484

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.jffs2_extract/0-484.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.jffs2_extract/0-484.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.jffs2_extract/0-484.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.jffs2_extract/0-484.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.jffs2_extract/0-484.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.jffs2_extract/0-484.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.padded.jffs2_extract/0-65536.jffs2_old
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.padded.jffs2_extract/0-65536.jffs2_old
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e967993964882a32ed168428ad30442c037f1a9e79ed8bb6a84a583a6c5593e
+size 65536

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c520551a1a5890fab0d252f7535c498f8e91aeb22b5cf8ab0d34d25c086f31
+size 26

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
+++ b/tests/integration/filesystem/jffs2/jffs2_old/__output__/fruits.old.le.zlib.padded.jffs2_extract/0-65536.jffs2_old_extract/fs_1/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -267,3 +267,14 @@ def get_endian(file: io.BufferedIOBase, big_endian_magic: int) -> Endian:
     magic = convert_int32(magic_bytes, Endian.BIG)
     endian = Endian.BIG if magic == big_endian_magic else Endian.LITTLE
     return endian
+
+
+def read_until_past(file: io.BufferedIOBase, pattern: bytes):
+    """Read until the bytes are not 0x00 or 0xff."""
+    while True:
+        next_byte = file.read(1)
+        if next_byte == b"":
+            # We've hit the EoF
+            return file.tell()
+        if next_byte not in pattern:
+            return file.tell() - 1

--- a/unblob/handlers/__init__.py
+++ b/unblob/handlers/__init__.py
@@ -3,13 +3,15 @@ from typing import List, Tuple, Type
 from ..models import Handler
 from .archive import ar, arc, arj, cab, cpio, dmg, rar, sevenzip, stuffit, tar, zip
 from .compression import bzip2, lz4, lzh, lzip, lzma, lzo, xz
-from .filesystem import cramfs, extfs, fat, iso9660, squashfs, ubi
+from .filesystem import cramfs, extfs, fat, iso9660, jffs2, squashfs, ubi
 
 ALL_HANDLERS_BY_PRIORITY: List[Tuple[Type[Handler], ...]] = [
     (
         cramfs.CramFSHandler,
         extfs.EXTHandler,
         fat.FATHandler,
+        jffs2.JFFS2NewHandler,
+        jffs2.JFFS2OldHandler,
         squashfs.SquashFSv3Handler,
         squashfs.SquashFSv4Handler,
         ubi.UBIHandler,

--- a/unblob/handlers/filesystem/jffs2.py
+++ b/unblob/handlers/filesystem/jffs2.py
@@ -1,0 +1,150 @@
+import io
+from typing import List, Optional
+
+from structlog import get_logger
+
+from unblob.file_utils import Endian, convert_int16, read_until_past, round_up
+
+from ...models import StructHandler, ValidChunk
+
+logger = get_logger()
+
+
+BLOCK_ALIGNMENT = 4
+JFFS2_MAGICS = [0x1985, 0x8519, 0x1984, 0x8419]
+
+# Compatibility flags.
+JFFS2_COMPAT_MASK = 0xC000
+JFFS2_NODE_ACCURATE = 0x2000
+JFFS2_FEATURE_INCOMPAT = 0xC000
+JFFS2_FEATURE_ROCOMPAT = 0x8000
+JFFS2_FEATURE_RWCOMPAT_COPY = 0x4000
+JFFS2_FEATURE_RWCOMPAT_DELETE = 0x0000
+
+DIRENT = JFFS2_FEATURE_INCOMPAT | JFFS2_NODE_ACCURATE | 1
+INODE = JFFS2_FEATURE_INCOMPAT | JFFS2_NODE_ACCURATE | 2
+CLEANMARKER = JFFS2_FEATURE_RWCOMPAT_DELETE | JFFS2_NODE_ACCURATE | 3
+PADDING = JFFS2_FEATURE_RWCOMPAT_DELETE | JFFS2_NODE_ACCURATE | 4
+SUMMARY = JFFS2_FEATURE_RWCOMPAT_DELETE | JFFS2_NODE_ACCURATE | 6
+XATTR = JFFS2_FEATURE_INCOMPAT | JFFS2_NODE_ACCURATE | 8
+XREF = JFFS2_FEATURE_INCOMPAT | JFFS2_NODE_ACCURATE | 9
+
+JFFS2_NODETYPES = {DIRENT, INODE, CLEANMARKER, PADDING, SUMMARY, XATTR, XREF}
+
+
+class _JFFS2Base(StructHandler):
+    C_DEFINITIONS = r"""
+        typedef struct jffs2_unknown_node
+        {
+            /* All start like this */
+            uint16 magic;
+            uint16 nodetype;
+            uint32 totlen; /* So we can skip over nodes we don't grok */
+            uint32 hdr_crc;
+        } jffs2_unknown_node_t;
+    """
+
+    HEADER_STRUCT = "jffs2_unknown_node_t"
+
+    BIG_ENDIAN_MAGIC = 0x19_85
+
+    def guess_endian(self, file: io.BufferedIOBase) -> Endian:
+        magic = convert_int16(file.read(2), Endian.BIG)
+        if magic == self.BIG_ENDIAN_MAGIC:
+            endian = Endian.BIG
+        else:
+            endian = Endian.LITTLE
+        file.seek(-2, io.SEEK_CUR)
+        return endian
+
+    def calculate_chunk(
+        self, file: io.BufferedIOBase, start_offset: int
+    ) -> Optional[ValidChunk]:
+
+        file.seek(0, io.SEEK_END)
+        eof = file.tell()
+        file.seek(start_offset)
+
+        endian = self.guess_endian(file)
+        current_offset = start_offset
+
+        while current_offset < eof:
+            node_start_offset = current_offset
+            file.seek(current_offset)
+            header = self.parse_header(file, endian=endian)
+
+            if header.magic not in JFFS2_MAGICS:
+                # JFFS2 allows padding at the end with 0xFF or 0x00, usually
+                # to the size of an erase block.
+                if header.magic in [0x0000, 0xFFFF]:
+                    file.seek(-len(header), io.SEEK_CUR)
+                    current_offset = read_until_past(file, b"\x00\xFF")
+                    continue
+                else:
+                    logger.debug("unexpected header magic", header_magic=header.magic)
+                    break
+
+            if header.nodetype not in JFFS2_NODETYPES:
+                logger.debug("Invalid JFFS2 node type", node_type=header.nodetype)
+                return
+
+            if node_start_offset + header.totlen > eof:
+                logger.debug(
+                    "node length greater than total file size",
+                    node_len=header.totlen,
+                    file_size=eof,
+                )
+                return
+
+            if header.totlen < len(header):
+                logger.debug(
+                    "node length greater than header size", node_len=header.totlen
+                )
+                return
+
+            node_len = round_up(header.totlen, BLOCK_ALIGNMENT)
+            file.seek(node_len, io.SEEK_CUR)
+            current_offset += node_len
+
+        if current_offset > eof:
+            # corrupt file or last chunk isn't really jffs2
+            return
+
+        return ValidChunk(
+            start_offset=start_offset,
+            end_offset=current_offset,
+        )
+
+    @staticmethod
+    def make_extract_command(inpath: str, outdir: str) -> List[str]:
+        return ["jefferson", "-v", "-f", "-d", outdir, inpath]
+
+
+class JFFS2OldHandler(_JFFS2Base):
+
+    NAME = "jffs2_old"
+
+    YARA_RULE = r"""
+        strings:
+            $jffs2_old_le = { 84 19 ( 01 | 02 | 03 | 04 | 06 | 08 | 09 ) ( e0 | 20 ) }
+            $jffs2_old_be = { 19 84 ( e0 | 20 ) ( 01 | 02 | 03 | 04 | 06 | 08 | 09 ) }
+        condition:
+            $jffs2_old_le or $jffs2_old_be
+    """
+
+    BIG_ENDIAN_MAGIC = 0x19_84
+
+
+class JFFS2NewHandler(_JFFS2Base):
+
+    NAME = "jffs2_new"
+
+    YARA_RULE = r"""
+        strings:
+            $jffs2_new_le = { 85 19 ( 01 | 02 | 03 | 04 | 06 | 08 | 09 ) ( e0 | 20 ) }
+            $jffs2_new_be = { 19 85 ( e0 | 20 ) ( 01 | 02 | 03 | 04 | 06 | 08 | 09 ) }
+        condition:
+            $jffs2_new_le or $jffs2_new_be
+    """
+
+    BIG_ENDIAN_MAGIC = 0x19_85


### PR DESCRIPTION
We add support for both JFFS2 new and JFFS2 old formats using a simple cparser, no external library required.

The extraction is performed by Jefferson (see https://github.com/sviehb/jefferson/). Given that it is MIT-licensed
we put it into unblob/extractors and applied some modifications to support JFFS2 old format too (only the magic
differs, the format stays the same).

Jefferson requires cstruct version 1.8 and fails with recent version such as 2.1 due to a breaking change in the API.
cstruct was therefore added to the poetry dependencies, enforcing version 1.8.

We also added the extractors directory to the flake8 exclusion list given that it would require a full rewrite of
any external tool we want to use (i.e. to severely reduce their cyclomatic complexity) in order to pass those checks.

Test files have been generated with mkfs.jffs2, with one version recompiled to use the old magic signature (0x1984).
Test files cover every possible test case in terms of signature, padding, endianness, and compression.

The following script was used to generate test files with two custom versions of mkfs.jffs2:

```bash
#!/bin/sh

KIND=(old new)
EXTFS=(jffs2)
ENDIAN=(l b)
COMPRESSION=(lzo zlib rtime)
LABEL="fruits"

rm -f /tmp/fruits*jffs2

mkdir -p "/tmp/fruits"
echo "AAAAAAAAAAAAAAAAAAAAAAAAA" > "/tmp/fruits/apple.txt"
echo "cherry" > "/tmp/fruits/cherry.txt"
echo "banana" > "/tmp/fruits/banana.txt"


get_endianness () {
    if [ "$1" == "b" ]; then
        echo "be";
    else
        echo "le";
    fi
}
    
# unpadded no compression

for ext in ${EXTFS[@]}; do
    for k in ${KIND[@]}; do
        for endian in ${ENDIAN[@]}; do
            e="$(get_endianness $endian)"
            echo "[+] crafting ${k} ${ext} fs with ${e} endian (not padded)"
            FILE="/tmp/fruits.${k}.${e}.nocomp.${ext}"
            ~/mtd-utils/mkfs.${ext}.${k} -v -x rtime -x lzo -x zlib -${endian} -d /tmp/fruits -o ${FILE}
            sleep 1
        done
    done
done

# unpadded with compression
for ext in ${EXTFS[@]}; do
    for k in ${KIND[@]}; do
        for endian in ${ENDIAN[@]}; do
            for comp in ${COMPRESSION[@]}; do
                e="$(get_endianness $endian)" 
                echo "[+] crafting ${k} ${ext} fs with ${e} endian and ${comp} compression (not padded)"
                FILE="/tmp/fruits.${k}.${e}.${comp}.${ext}"
                ~/mtd-utils/mkfs.${ext}.${k} -v -X $comp -y 100:${comp} -${endian} -d /tmp/fruits -o ${FILE}
                sleep 1
            done
        done
    done
done

# padded no compression

for ext in ${EXTFS[@]}; do
    for k in ${KIND[@]}; do
        for endian in ${ENDIAN[@]}; do
            e="$(get_endianness $endian)" 
            echo "[+] crafting ${k} ${ext} fs with ${e} endian (padded)"
            FILE="/tmp/fruits.${k}.${e}.nocomp.padded.${ext}"
            ~/mtd-utils/mkfs.${ext}.${k} -v -x rtime -x lzo -x zlib -p -${endian} -d /tmp/fruits -o ${FILE}
            sleep 1
        done
    done
done

# padded with compression
for ext in ${EXTFS[@]}; do
    for k in ${KIND[@]}; do
        for endian in ${ENDIAN[@]}; do
            for comp in ${COMPRESSION[@]}; do
                e="$(get_endianness $endian)" 
                echo "[+] crafting ${k} ${ext} fs with ${e} endian and ${comp} compression (padded)"
                FILE="/tmp/fruits.${k}.${e}.${comp}.padded.${ext}"
                ~/mtd-utils/mkfs.${ext}.${k} -v -p -X $comp -y 100:${comp} -${endian} -d /tmp/fruits -o ${FILE}
                sleep 1
            done
        done
    done
done
```

