### PR TITLE
Multiple Dockerfile improvements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.8-slim
 
 RUN mkdir -p /data/input /data/output
-RUN useradd unblob
+RUN useradd -m unblob
+RUN chown -R unblob /data
 
-ENTRYPOINT ["unblob"]
+WORKDIR /data/output
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     unar \
@@ -13,14 +14,18 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     lziprecover \
     lzop \
     lz4 \
+    xz-utils \
     squashfs-tools \
-    p7zip-full
+    curl
+RUN curl -s https://www.7-zip.org/a/7z2107-linux-x64.tar.xz --output - \
+    | tar -C /usr/local/bin --transform 's/7zzs/7z/' -Jxvf - 7zzs
 
+USER unblob
+ENV PATH="/home/unblob/.local/bin:${PATH}"
 
 # You MUST do a poetry build before to have the wheel to copy & install here (CI action will do this when building)
 COPY dist/*.whl /tmp/
+RUN pip --disable-pip-version-check install --upgrade pip
 RUN pip install /tmp/unblob*.whl
 
-WORKDIR /data/output
-RUN chown -R unblob /data
-USER unblob
+ENTRYPOINT ["unblob"]


### PR DESCRIPTION
- install 7zip version 21.07 manually
- upgrade pip to latest version to get rid of warning messages
- perform unblob installation as unblob user rather than system-wide install as root