### PR TITLE
bzip2_recover RIIR (rewrite it in rust)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "fastrand"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,9 +285,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.111"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e167738f1866a7ec625567bae89ca0d44477232a4f7c52b1c7f2adc2c98804f"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "lock_api"
@@ -590,6 +599,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +699,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,8 +737,10 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "criterion",
+ "libc",
  "pyo3",
  "rand",
+ "tempfile",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,13 +11,17 @@ crate-type = [
 ]
 
 [dependencies]
+libc = "0.2.112"
 pyo3 = "0.15.1"
 
 [dev-dependencies]
 approx = "0.5.0"
 criterion = "0.3.5"
 rand = "0.8.4"
+tempfile = "3.3.0"
 
 [[bench]]
 name = "benches_main"
 harness = false
+
+[features]

--- a/rust/src/bzip2.rs
+++ b/rust/src/bzip2.rs
@@ -1,0 +1,63 @@
+use std::io::{Read, Result, Seek, SeekFrom};
+
+const BLOCK_HEADER: u64 = 0x0000_3141_5926_5359;
+const BLOCK_ENDMARK: u64 = 0x0000_1772_4538_5090;
+
+const COMPRESSED_MAGIC_LENGTH: u64 = 6 * 8;
+
+pub fn bzip2_recover(mut file: impl Read + Seek, start_offset: u64) -> Result<Option<u64>> {
+    let mut bits_read = 0;
+    let mut buff = 0;
+    let mut blocks_found = 0;
+    let mut current_block_end = 0;
+
+    file.seek(SeekFrom::Start(start_offset))?;
+
+    let mut io_buff = vec![0; 1 << 16];
+
+    while let Ok(read) = file.read(&mut io_buff) {
+        if read == 0 {
+            break;
+        }
+
+        for byte in &io_buff[0..read] {
+            for offset in (0..=7).rev() {
+                bits_read += 1;
+                buff = (buff << 1 | ((byte >> offset) & 1) as u64) & 0xFFFF_FFFF_FFFF;
+
+                if buff == BLOCK_HEADER || buff == BLOCK_ENDMARK {
+                    blocks_found += 1;
+                    current_block_end = bits_read;
+                }
+            }
+        }
+    }
+    if blocks_found < 2 {
+        return Ok(None);
+    }
+
+    let end_block_offset = bits_to_bytes(current_block_end);
+    Ok(Some(start_offset + end_block_offset))
+}
+
+
+fn bits_to_bytes(number: u64) -> u64 {
+    let rounded_up = (number + 7) & !7;
+
+    rounded_up >> 3
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bits_to_bytes() {
+        assert_eq!(bits_to_bytes(0b0), 0);
+        assert_eq!(bits_to_bytes(0b1), 1);
+        assert_eq!(bits_to_bytes(0b0100_0000), 8);
+        assert_eq!(bits_to_bytes(0b1000_0000), 16);
+        assert_eq!(bits_to_bytes(0b1111_1111), 32);
+        assert_eq!(bits_to_bytes(0b1_0000_0000), 32);
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,4 +1,6 @@
+pub(crate) mod bzip2;
 pub(crate) mod math;
+pub(crate) mod python;
 
 use pyo3::prelude::*;
 
@@ -8,9 +10,20 @@ pub fn shannon_entropy(data: &[u8]) -> PyResult<f64> {
     Ok(math::shannon_entropy(data))
 }
 
+/// Get the end of a `bzip2` stream in a file
+#[pyfunction(text_signature = "(file)")]
+pub fn bzip2_recover(file: python::FileLike, start_offset: u64) -> PyResult<i64> {
+    if let Some(end) = bzip2::bzip2_recover(file, start_offset)? {
+        Ok(end as i64)
+    } else {
+        Ok(-1)
+    }
+}
+
 /// Performance sensitive functionality
 #[pymodule]
 fn _rust(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(shannon_entropy, m)?)?;
+    m.add_function(wrap_pyfunction!(bzip2_recover, m)?)?;
     Ok(())
 }

--- a/rust/src/python.rs
+++ b/rust/src/python.rs
@@ -1,0 +1,214 @@
+//! # Python interop helpers
+//!
+//! The Python interop library [PyO3](https://pyo3.rs) has a bunch of
+//! helpers to seamlessly transform between Rust and Python data-types
+//! but it is far from incomplete.
+//!
+//! This module contains additional type conversion definitions. As it
+//! is impossible to extend externally defined types with externally
+//! defined traits, this modue defines wrapper types to circumwent
+//! this limitation. These wrappers can be converted to their standard
+//! library conterparts.
+
+use pyo3::{exceptions::PyTypeError, ffi, prelude::*};
+use std::{
+    io::{Error, Read, Seek},
+    os::unix::prelude::FromRawFd,
+};
+
+/// Encodes arbitrary Python file like objects. If the file-like
+/// object represents a real file, then it is converted to an
+/// [`std::fs::File`] object providing low-owerhead file IO.
+pub enum FileLike<'a> {
+    File(std::fs::File),
+    Other(PyFileLike<'a>),
+}
+
+/// Wraps an arbitrary readable and seekable file-like object
+pub struct PyFileLike<'a> {
+    read: &'a PyAny,
+    seek: &'a PyAny,
+}
+
+impl<'a> TryFrom<&'a PyAny> for PyFileLike<'a> {
+    type Error = PyErr;
+
+    fn try_from(value: &'a PyAny) -> Result<Self, Self::Error> {
+        let read = value.getattr("read")?;
+        let seek = value.getattr("seek")?;
+        Ok(PyFileLike { read, seek })
+    }
+}
+
+impl<'a> Read for PyFileLike<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let result = self.read.call1((buf.len(),))?;
+        let bytes: &[u8] = result.extract()?;
+        buf[0..bytes.len()].copy_from_slice(bytes);
+        Ok(bytes.len())
+    }
+}
+
+impl<'a> Seek for PyFileLike<'a> {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        let args = match pos {
+            std::io::SeekFrom::Start(o) => (o as i64, 0),
+            std::io::SeekFrom::Current(o) => (o, 1),
+            std::io::SeekFrom::End(o) => (o, 2),
+        };
+
+        let result = self.seek.call1(args)?.extract()?;
+        Ok(result)
+    }
+}
+
+impl<'a> FileLike<'a> {
+    fn from_other(file_like: &'a PyAny) -> PyResult<Self> {
+        Ok(Self::Other(PyFileLike::try_from(file_like)?))
+    }
+
+    fn from_fd(fd: i32) -> PyResult<Self> {
+        // Duplicate the file descriptor as we cannot transfer
+        // ownership of a Python object to a Rust one. `std::fs::File`
+        // assumes ownership to the contained fd.
+        //
+        // Unsafe because conversion is fallible. Returns `-1` on
+        // error.
+        //
+        // F_DUPFD_CLOEXEC is passed to ensure that we don't leek the
+        // allocated fd in child processes which would otherwise
+        // inherit it.
+        //
+        // The 3rd argument is the lowest available file descriptor we
+        // want. As we don't care about the actual number of the fd,
+        // hence the 0.
+        //
+        // Reference:
+        // [https://man7.org/linux/man-pages/man2/fcntl.2.html]
+        // [https://www.gnu.org/software/libc/manual/html_node/Duplicating-Descriptors.html]
+        let fd = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
+        if fd == -1 {
+            let errno = Error::last_os_error().raw_os_error();
+            return Err(PyTypeError::new_err((
+                "Dup failed for file descriptor",
+                errno,
+            )));
+        }
+
+        // Unsafe only if the wrapper is not the sole owner of the wrapped fd.
+        let std_file = unsafe { std::fs::File::from_raw_fd(fd) };
+        Ok(Self::File(std_file))
+    }
+}
+
+impl<'a> Read for FileLike<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Self::File(f) => f.read(buf),
+            Self::Other(f) => f.read(buf),
+        }
+    }
+}
+
+impl<'a> Seek for FileLike<'a> {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        match self {
+            Self::File(f) => f.seek(pos),
+            Self::Other(f) => f.seek(pos),
+        }
+    }
+}
+
+impl<'a> FromPyObject<'a> for FileLike<'a> {
+    fn extract(file: &'a PyAny) -> PyResult<Self> {
+        // Unsafe because conversion is fallible. Returns `-1` on error
+        // Reference: [https://docs.python.org/3/c-api/file.html#c.PyObject_AsFileDescriptor]
+        let fd = unsafe { ffi::PyObject_AsFileDescriptor(file.into_ptr()) };
+        if fd != -1 {
+            Self::from_fd(fd)
+        } else {
+            // Ok, let's assume it is not a real file and go-on.
+            unsafe { ffi::PyErr_Clear() };
+            Self::from_other(file)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pyo3::types::{IntoPyDict, PyBytes, PyString};
+    use std::{
+        error::Error,
+        io::{Read, Write},
+    };
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[test]
+    fn test_rust_file_from_python_file_object() -> Result<(), Box<dyn Error>> {
+        // Set up a real file on the file system with some real contents
+        let test_file_contents = "Hello from Python!";
+        let mut test_file = NamedTempFile::new()?;
+        write!(test_file, "{}", test_file_contents)?;
+
+        // Open the file a second time from an embedded Python
+        // interpreter and convert it to a Rust file object...
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| -> PyResult<()> {
+            // Set the path to the test file as a local variable in the Python interpreter
+            let locals = [(
+                "testfile_path",
+                PyString::new(py, test_file.path().to_str().unwrap()),
+            )]
+            .into_py_dict(py);
+
+            // To get a Python file object...
+            py.run(r#"py_fp = open(testfile_path, "rb")"#, None, Some(locals))?;
+
+            // And a reference to it from Rust code...
+            let py_fp = locals.get_item("py_fp").unwrap();
+
+            let mut file_like: FileLike = py_fp.extract()?;
+            let mut contents = String::new();
+            file_like.read_to_string(&mut contents)?;
+
+            assert_eq!(contents, test_file_contents);
+
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_rust_file_from_python_bytesio_object() -> Result<(), Box<dyn Error>>
+    {
+        let test_file_contents = "Hello from Python!";
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| -> PyResult<()> {
+            // Set the path to the test file as a local variable in the Python interpreter
+            let locals = [(
+                "test_file_contents",
+                PyBytes::new(py, test_file_contents.as_bytes()),
+            )]
+            .into_py_dict(py);
+
+            // To get a Python file object...
+            py.run(
+                r#"import io; bytesio = io.BytesIO(test_file_contents)"#,
+                None,
+                Some(locals),
+            )?;
+
+            let bytes_io = locals.get_item("bytesio").unwrap();
+            let mut file_like: FileLike = bytes_io.extract()?;
+            let mut contents = String::new();
+            file_like.read_to_string(&mut contents)?;
+
+            assert_eq!(contents, test_file_contents);
+
+            Ok(())
+        })?;
+        Ok(())
+    }
+}

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1,3 +1,4 @@
+import io
 import pytest
 from pytest import approx
 
@@ -37,3 +38,115 @@ def binding(request):
 )
 def test_shannon_entropy(binding, data, entropy):
     assert binding.shannon_entropy(data) == approx(entropy)
+
+BLOCK_HEADER = b"\x31\x41\x59\x26\x53\x59"
+BLOCK_ENDMARK = b"\x17\x72\x45\x38\x50\x90"
+
+
+def shift_left(value: bytes, bits: int) -> bytes:
+    # big endian to keep the order
+    left_shifted = int.from_bytes(value, byteorder="big") << bits
+    return left_shifted.to_bytes(7, byteorder="big")
+
+
+@pytest.mark.parametrize(
+    "content, start_offset, expected_end_offset",
+    (
+        pytest.param(b"123", 0, -1, id="shorter_than_block"),
+        pytest.param(b"asdfasdf", 0, -1, id="not_found"),
+        pytest.param(
+            BLOCK_HEADER + b"123" + BLOCK_ENDMARK, 0, 15, id="aligned_to_zero"
+        ),
+        pytest.param(
+            b"0123" + BLOCK_HEADER + b"456" + BLOCK_ENDMARK,
+            4,
+            19,
+            id="aligned_with_offset",
+        ),
+        pytest.param(
+            b"0123" + BLOCK_HEADER + BLOCK_ENDMARK,
+            4,
+            16,
+            id="aligned_offset_empty_content",
+        ),
+        pytest.param(b"0123" + BLOCK_HEADER, 0, -1, id="no_block_endmark"),
+        pytest.param(b"0123" + BLOCK_ENDMARK, 0, -1, id="no_block_header"),
+        # extra byte when shifted
+        pytest.param(
+            shift_left(BLOCK_HEADER, 1) + b"123" + BLOCK_ENDMARK,
+            0,
+            16,
+            id="block_header_left_shifted_by_1",
+        ),
+        pytest.param(
+            shift_left(BLOCK_HEADER, 7) + b"123" + BLOCK_ENDMARK,
+            0,
+            16,
+            id="block_header_left_shifted_by_7",
+        ),
+        pytest.param(
+            BLOCK_HEADER + b"123" + shift_left(BLOCK_ENDMARK, 1),
+            0,
+            16,
+            id="block_endmark_left_shifted_by_1",
+        ),
+        pytest.param(
+            BLOCK_HEADER + b"123" + shift_left(BLOCK_ENDMARK, 7),
+            0,
+            16,
+            id="block_endmark_left_shifted_by_7",
+        ),
+        pytest.param(
+            shift_left(BLOCK_HEADER, 1) + b"123" + shift_left(BLOCK_ENDMARK, 1),
+            0,
+            17,
+            id="both_marks_shifted_by_1",
+        ),
+        pytest.param(
+            shift_left(BLOCK_HEADER, 7) + b"123" + shift_left(BLOCK_ENDMARK, 7),
+            0,
+            17,
+            id="both_marks_shifted_by_7",
+        ),
+        pytest.param(
+            BLOCK_HEADER
+            + b"123"
+            + BLOCK_ENDMARK
+            + b"AAAA"
+            + BLOCK_HEADER
+            + b"123"
+            + BLOCK_ENDMARK,
+            0,
+            15,
+            id="two_bzip2_streams_separated_by_garbage_1",
+        ),
+        pytest.param(
+            BLOCK_HEADER
+            + b"123"
+            + BLOCK_ENDMARK
+            + BLOCK_HEADER
+            + b"123"
+            + BLOCK_ENDMARK,
+            0,
+            30,
+            id="two_bzip2_streams",
+        ),
+        pytest.param(
+            BLOCK_HEADER
+            + b"123"
+            + BLOCK_ENDMARK
+            + BLOCK_HEADER
+            + b"123"
+            + BLOCK_ENDMARK
+            + b"AAAA",
+            0,
+            30,
+            id="two_bzip2_streams_followed_by_garbage_2",
+        ),
+        # undefined behavior: (BLOCK_ENDMARK + BLOCK_HEADER, 0, -1),
+    ),
+)
+def test_bzip2_recover_x(binding, content: bytes, start_offset: int, expected_end_offset: int):
+    fake_file = io.BytesIO(content)
+    end_offset = binding.bzip2_recover(fake_file, start_offset)
+    assert end_offset == expected_end_offset

--- a/unblob/_py/__init__.py
+++ b/unblob/_py/__init__.py
@@ -1,3 +1,4 @@
 """Python implementation of the algorithms found in the Rust extension module"""
 
 from .math import shannon_entropy
+from .bzip2 import bzip2_recover

--- a/unblob/_py/bzip2.py
+++ b/unblob/_py/bzip2.py
@@ -1,0 +1,49 @@
+import io
+
+from unblob.file_utils import iterbits, round_up
+
+
+BLOCK_HEADER = 0x0000_3141_5926_5359
+BLOCK_ENDMARK = 0x0000_1772_4538_5090
+
+COMPRESSED_MAGIC_LENGTH = 6 * 8
+
+BLOCK_ENDMARK_SHIFTED = BLOCK_ENDMARK << COMPRESSED_MAGIC_LENGTH
+
+
+def bzip2_recover(file: io.BufferedIOBase, start_offset: int) -> int:
+    """Emulate the behavior of bzip2recover, matching on compressed magic and end of stream
+        magic to identify the end offset of the whole bzip2 chunk.
+        Count from absolute start_offset and returns absolute end_offset
+        (first byte after the chunk ends).
+        """
+
+    bits_read = 0
+    buff = 0
+    current_block_end = 0
+    start_block_found = False
+    end_block_found = False
+
+    file.seek(start_offset)
+
+    for b in iterbits(file):
+        bits_read += 1
+
+        buff = (buff << 1 | b) & 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF
+
+        if buff & 0xFFFF_FFFF_FFFF == BLOCK_HEADER:
+            start_block_found = True
+        elif buff & 0xFFFF_FFFF_FFFF == BLOCK_ENDMARK:
+            end_block_found = True
+            current_block_end = bits_read
+        elif buff & 0xFFFF_FFFF_FFFF_0000_0000_0000 == BLOCK_ENDMARK_SHIFTED:
+            if buff & 0xFFFF_FFFF_FFFF == BLOCK_HEADER:
+                continue
+            break
+
+    if not (start_block_found and end_block_found):
+        return -1
+
+    # blocks are counted in bits but we need an offset in bytes
+    end_block_offset = round_up(current_block_end, 8) // 8
+    return start_offset + end_block_offset


### PR DESCRIPTION
Added some performance tests for the bzip2 case. (Also have an idea how to run all integration tests optionally as a benchmark as well. Stay tuned). I haven't tested yet if the rust code actually is correct, my goal was to see how it scales differently.

<details>
  <summary>Measurements (click to expand)</summary>

A naive rewrite in rust brings in a whopping 400 fold improvement:

```console
$ UNBLOB_BUILD_RUST_EXTENSION=1 poetry install
Installing dependencies from lock file

No dependencies to install or update

Installing the current project: unblob (0.1.0)
$ .venv/bin/pytest --no-cov -v benches
=================================================================================================================== test session starts ====================================================================================================================
platform linux -- Python 3.9.6, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/vlaci/devel/git/github.com/IoT-Inspector/unblob/.venv/bin/python
cachedir: .pytest_cache
benchmark: 3.4.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/vlaci/devel/git/github.com/IoT-Inspector/unblob/benches, configfile: pytest.ini
plugins: cov-3.0.0, benchmark-3.4.1
collected 2 items                                                                                                                                                                                                                                          

benches/bench_bzip2.py::bench_bzip2_recover_python PASSED                                                                                                                                                                                            [ 50%]
benches/bench_bzip2.py::bench_bzip2_recover_rust PASSED                                                                                                                                                                                              [100%]
Saved benchmark data in: /home/vlaci/devel/git/github.com/IoT-Inspector/unblob/.benchmarks/Linux-CPython-3.9-64bit/0008_a419087dbaf8822ebaffaf7fba1831643df09a7b_20220111_093639_uncommited-changes.json



-------------------------------------------------------------------------------------------- benchmark: 2 tests --------------------------------------------------------------------------------------------
Name (time in ms)                     Min                   Max                  Mean            StdDev                Median                IQR            Outliers       OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_bzip2_recover_rust           6.0643 (1.0)          7.2804 (1.0)          6.1517 (1.0)      0.1284 (1.0)          6.1202 (1.0)       0.0205 (1.0)          7;26  162.5563 (1.0)         147           1
bench_bzip2_recover_python     2,520.3483 (415.61)   2,537.2174 (348.50)   2,527.8006 (410.91)   8.2568 (64.31)    2,524.2019 (412.44)   15.5520 (757.52)        2;0    0.3956 (0.00)          5           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
==================================================================================================================== 2 passed in 20.93s ====================================================================================================================
```

</details>