### PR TITLE
Fix bzip2 handler to stop early

### DIFF
--- a/tests/handlers/compression/test_bzip2.py
+++ b/tests/handlers/compression/test_bzip2.py
@@ -19,17 +19,19 @@ def shift_left(value: bytes, bits: int) -> bytes:
     (
         pytest.param(b"123", 0, -1, id="shorter_than_block"),
         pytest.param(b"asdfasdf", 0, -1, id="not_found"),
-        pytest.param(BLOCK_HEADER + b"123" + BLOCK_ENDMARK, 0, 9, id="aligned_to_zero"),
+        pytest.param(
+            BLOCK_HEADER + b"123" + BLOCK_ENDMARK, 0, 15, id="aligned_to_zero"
+        ),
         pytest.param(
             b"0123" + BLOCK_HEADER + b"456" + BLOCK_ENDMARK,
             4,
-            13,
+            19,
             id="aligned_with_offset",
         ),
         pytest.param(
             b"0123" + BLOCK_HEADER + BLOCK_ENDMARK,
             4,
-            10,
+            16,
             id="aligned_offset_empty_content",
         ),
         pytest.param(b"0123" + BLOCK_HEADER, 0, -1, id="no_block_endmark"),
@@ -38,38 +40,73 @@ def shift_left(value: bytes, bits: int) -> bytes:
         pytest.param(
             shift_left(BLOCK_HEADER, 1) + b"123" + BLOCK_ENDMARK,
             0,
-            10,
+            16,
             id="block_header_left_shifted_by_1",
         ),
         pytest.param(
             shift_left(BLOCK_HEADER, 7) + b"123" + BLOCK_ENDMARK,
             0,
-            10,
+            16,
             id="block_header_left_shifted_by_7",
         ),
         pytest.param(
             BLOCK_HEADER + b"123" + shift_left(BLOCK_ENDMARK, 1),
             0,
-            10,
+            16,
             id="block_endmark_left_shifted_by_1",
         ),
         pytest.param(
             BLOCK_HEADER + b"123" + shift_left(BLOCK_ENDMARK, 7),
             0,
-            10,
+            16,
             id="block_endmark_left_shifted_by_7",
         ),
         pytest.param(
             shift_left(BLOCK_HEADER, 1) + b"123" + shift_left(BLOCK_ENDMARK, 1),
             0,
-            11,
+            17,
             id="both_marks_shifted_by_1",
         ),
         pytest.param(
             shift_left(BLOCK_HEADER, 7) + b"123" + shift_left(BLOCK_ENDMARK, 7),
             0,
-            11,
+            17,
             id="both_marks_shifted_by_7",
+        ),
+        pytest.param(
+            BLOCK_HEADER
+            + b"123"
+            + BLOCK_ENDMARK
+            + b"AAAA"
+            + BLOCK_HEADER
+            + b"123"
+            + BLOCK_ENDMARK,
+            0,
+            15,
+            id="two_bzip2_streams_separated_by_garbage_1",
+        ),
+        pytest.param(
+            BLOCK_HEADER
+            + b"123"
+            + BLOCK_ENDMARK
+            + BLOCK_HEADER
+            + b"123"
+            + BLOCK_ENDMARK,
+            0,
+            30,
+            id="two_bzip2_streams",
+        ),
+        pytest.param(
+            BLOCK_HEADER
+            + b"123"
+            + BLOCK_ENDMARK
+            + BLOCK_HEADER
+            + b"123"
+            + BLOCK_ENDMARK
+            + b"AAAA",
+            0,
+            30,
+            id="two_bzip2_streams_followed_by_garbage_2",
         ),
         # undefined behavior: (BLOCK_ENDMARK + BLOCK_HEADER, 0, -1),
     ),

--- a/tests/integration/compression/bzip2/__input__/dual.txt.bzip2
+++ b/tests/integration/compression/bzip2/__input__/dual.txt.bzip2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9b1a23a1a225025ca32125b4156b6af67b712db911c08b0548f3e90131788df
+size 5099

--- a/tests/integration/compression/bzip2/__output__/dual.txt.bzip2_extract/0-2545.bzip2
+++ b/tests/integration/compression/bzip2/__output__/dual.txt.bzip2_extract/0-2545.bzip2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92cf0f3476c5cd45d112985624be66a543fbb92f46142cd579a778795f1cea03
+size 2545

--- a/tests/integration/compression/bzip2/__output__/dual.txt.bzip2_extract/0-2545.bzip2_extract/0-2545
+++ b/tests/integration/compression/bzip2/__output__/dual.txt.bzip2_extract/0-2545.bzip2_extract/0-2545
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6015681ff30441238676a933d6920ed2691e04b9d992ac2aaeab9a62bca9553
+size 6560

--- a/tests/integration/compression/bzip2/__output__/dual.txt.bzip2_extract/2545-2554.unknown
+++ b/tests/integration/compression/bzip2/__output__/dual.txt.bzip2_extract/2545-2554.unknown
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62de6306211cb0e6bd25c6fa452659e65f759b01fce630d027f5b781b14bd858
+size 9

--- a/tests/integration/compression/bzip2/__output__/dual.txt.bzip2_extract/2554-5099.bzip2
+++ b/tests/integration/compression/bzip2/__output__/dual.txt.bzip2_extract/2554-5099.bzip2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92cf0f3476c5cd45d112985624be66a543fbb92f46142cd579a778795f1cea03
+size 2545

--- a/tests/integration/compression/bzip2/__output__/dual.txt.bzip2_extract/2554-5099.bzip2_extract/2554-5099
+++ b/tests/integration/compression/bzip2/__output__/dual.txt.bzip2_extract/2554-5099.bzip2_extract/2554-5099
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6015681ff30441238676a933d6920ed2691e04b9d992ac2aaeab9a62bca9553
+size 6560


### PR DESCRIPTION
Fix #164 by making sure we return as soon as we find the end mark instead of reading until the end of the file. This was causing problems when a file is composed of multiple bzip2 streams with random data in between.

A test file representing this exact test case has been added to bzip2 integration tests, along with a pytest case in test_bzip2.py