### PR TITLE
Normalize C struct conventions in C_DEFINITIONS

### DIFF
--- a/unblob/handlers/archive/arc.py
+++ b/unblob/handlers/archive/arc.py
@@ -34,7 +34,7 @@ class ARCHandler(StructHandler):
     """
 
     C_DEFINITIONS = r"""
-    struct heads {			/* archive entry header format */
+    typedef struct arc_head {			/* archive entry header format */
         int8 archive_marker;
         int8 header_type;
         char    name[13];		/* file name */
@@ -43,10 +43,10 @@ class ARCHandler(StructHandler):
         ushort time;	/* creation time */
         short crc;	/* cyclic redundancy check */
         ulong length;	/* true file length */
-    };
+    } arc_head_t;
     """
 
-    HEADER_STRUCT = "heads"
+    HEADER_STRUCT = "arc_head_t"
 
     def valid_name(self, name: bytes) -> bool:
         try:

--- a/unblob/handlers/archive/cab.py
+++ b/unblob/handlers/archive/cab.py
@@ -19,32 +19,32 @@ class CABHandler(StructHandler):
     """
 
     C_DEFINITIONS = r"""
-        struct cab_header
+        typedef struct cab_header
         {
-            u1  signature[4];  /* cabinet file signature contains the characters 'M','S','C','F' (bytes 0x4D, 0x53, 0x43, 0x46). */
+            char  signature[4];  /* cabinet file signature contains the characters 'M','S','C','F' (bytes 0x4D, 0x53, 0x43, 0x46). */
                                 /* This field is used to assure that the file is a cabinet file. */
-            u4  reserved1;     /* reserved */
-            u4  cbCabinet;     /* size of this cabinet file in bytes */
-            u4  reserved2;     /* reserved */
-            u4  coffFiles;     /* offset of the first CFFILE entry */
-            u4  reserved3;     /* reserved */
-            u1  versionMinor;  /* cabinet file format version, minor */
-            u1  versionMajor;  /* cabinet file format version, major */
-            u2  cFolders;      /* number of CFFOLDER entries in this cabinet */
-            u2  cFiles;        /* number of CFFILE entries in this cabinet */
-            u2  flags;         /* cabinet file option indicators */
-            u2  setID;         /* must be the same for all cabinets in a set*/
-            u2  iCabinet;     /* number of this cabinet file in a set */
-            u2  cbCFHeader;   /* (optional) size of per-cabinet reserved area */
-            u1  cbCFFolder;   /* (optional) size of per-folder reserved area */
-            u1  cbCFData;         /* (optional) size of per-datablock reserved area */
-            u1  szCabinetPrev[];  /* (optional) name of previous cabinet file */
-            u1  szDiskPrev[];     /* (optional) name of previous disk */
-            u1  szCabinetNext[];  /* (optional) name of next cabinet file */
-            u1  szDiskNext[];     /* (optional) name of next disk */
-        };
+            uint32  reserved1;     /* reserved */
+            uint32  cbCabinet;     /* size of this cabinet file in bytes */
+            uint32  reserved2;     /* reserved */
+            uint32  coffFiles;     /* offset of the first CFFILE entry */
+            uint32  reserved3;     /* reserved */
+            uint8  versionMinor;  /* cabinet file format version, minor */
+            uint8  versionMajor;  /* cabinet file format version, major */
+            uint16  cFolders;      /* number of CFFOLDER entries in this cabinet */
+            uint16  cFiles;        /* number of CFFILE entries in this cabinet */
+            uint16  flags;         /* cabinet file option indicators */
+            uint16  setID;         /* must be the same for all cabinets in a set*/
+            uint16  iCabinet;     /* number of this cabinet file in a set */
+            uint16  cbCFHeader;   /* (optional) size of per-cabinet reserved area */
+            uint8  cbCFFolder;   /* (optional) size of per-folder reserved area */
+            uint8  cbCFData;         /* (optional) size of per-datablock reserved area */
+            uint8  szCabinetPrev[];  /* (optional) name of previous cabinet file */
+            uint8  szDiskPrev[];     /* (optional) name of previous disk */
+            uint8  szCabinetNext[];  /* (optional) name of next cabinet file */
+            uint8  szDiskNext[];     /* (optional) name of next disk */
+        } cab_header_t;
     """
-    HEADER_STRUCT = "cab_header"
+    HEADER_STRUCT = "cab_header_t"
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int

--- a/unblob/handlers/archive/cpio.py
+++ b/unblob/handlers/archive/cpio.py
@@ -97,22 +97,22 @@ class BinaryHandler(_CPIOHandlerBase):
     """
 
     C_DEFINITIONS = r"""
-        struct old_cpio_header
+        typedef struct old_cpio_header
         {
-            ushort c_magic;
-            ushort c_dev;
-            ushort c_ino;
-            ushort c_mode;
-            ushort c_uid;
-            ushort c_gid;
-            ushort c_nlink;
-            ushort c_rdev;
-            ushort c_mtimes[2];
-            ushort c_namesize;
-            ushort c_filesize[2];
-        };
+            uint16 c_magic;
+            uint16 c_dev;
+            uint16 c_ino;
+            uint16 c_mode;
+            uint16 c_uid;
+            uint16 c_gid;
+            uint16 c_nlink;
+            uint16 c_rdev;
+            uint16 c_mtimes[2];
+            uint16 c_namesize;
+            uint16 c_filesize[2];
+        } old_cpio_header_t;
     """
-    HEADER_STRUCT = "old_cpio_header"
+    HEADER_STRUCT = "old_cpio_header_t"
 
     _PAD_ALIGN = 2
 
@@ -136,7 +136,7 @@ class PortableOldASCIIHandler(_CPIOHandlerBase):
             $cpio_portable_old_ascii_magic
     """
     C_DEFINITIONS = r"""
-        struct old_ascii_header
+        typedef struct old_ascii_header
         {
             char c_magic[6];
             char c_dev[6];
@@ -149,9 +149,9 @@ class PortableOldASCIIHandler(_CPIOHandlerBase):
             char c_mtime[11];
             char c_namesize[6];
             char c_filesize[11];
-        };
+        } old_ascii_header_t;
     """
-    HEADER_STRUCT = "old_ascii_header"
+    HEADER_STRUCT = "old_ascii_header_t"
 
     _PAD_ALIGN = 2
 
@@ -166,7 +166,7 @@ class PortableOldASCIIHandler(_CPIOHandlerBase):
 
 class _NewASCIICommon(StructHandler):
     C_DEFINITIONS = r"""
-        struct new_ascii_header
+        typedef struct new_ascii_header
         {
             char c_magic[6];
             char c_ino[8];
@@ -182,9 +182,9 @@ class _NewASCIICommon(StructHandler):
             char c_rdev_min[8];
             char c_namesize[8];
             char c_chksum[8];
-        };
+        } new_ascii_header_t;
     """
-    HEADER_STRUCT = "new_ascii_header"
+    HEADER_STRUCT = "new_ascii_header_t"
 
     _PAD_ALIGN = 4
 

--- a/unblob/handlers/archive/dmg.py
+++ b/unblob/handlers/archive/dmg.py
@@ -22,7 +22,7 @@ class DMGHandler(StructHandler):
 
     C_DEFINITIONS = r"""
         // source: http://newosxbook.com/DMG.html
-        typedef struct {
+        typedef struct dmg_header {
             char     Signature[4];          // Magic ('koly')
             uint32 Version;               // Current version is 4
             uint32 HeaderSize;            // sizeof(this), always 512
@@ -55,9 +55,9 @@ class DMGHandler(StructHandler):
             uint32 reserved3;             // 0
             uint32 reserved4;             // 0
 
-        } UDIFResourceFile;
+        } dmg_header_t;
     """
-    HEADER_STRUCT = "UDIFResourceFile"
+    HEADER_STRUCT = "dmg_header_t"
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int

--- a/unblob/handlers/archive/sevenzip.py
+++ b/unblob/handlers/archive/sevenzip.py
@@ -36,12 +36,11 @@ class SevenZipHandler(StructHandler):
         strings:
             // '7', 'z', 0xBC, 0xAF, 0x27, 0x1C
             $sevenzip_magic = { 37 7A BC AF 27 1C }
-
         condition:
             $sevenzip_magic
     """
     C_DEFINITIONS = r"""
-        struct sevenzip_header {
+        typedef struct sevenzip_header {
             char magic[6];
             uint8 version_maj;
             uint8 version_min;
@@ -49,13 +48,9 @@ class SevenZipHandler(StructHandler):
             uint64 next_header_offset;
             uint64 next_header_size;
             uint32 next_header_crc;
-        }
-
-        struct header_db {
-            char property_id;
-        }
+        } sevenzip_header_t;
     """
-    HEADER_STRUCT = "sevenzip_header"
+    HEADER_STRUCT = "sevenzip_header_t"
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int

--- a/unblob/handlers/archive/stuffit.py
+++ b/unblob/handlers/archive/stuffit.py
@@ -55,15 +55,15 @@ class StuffItSITHandler(_StuffItHandlerBase):
     """
 
     C_DEFINITIONS = r"""
-        struct sit_header
+        typedef struct sit_header
         {
             char signature[4];
             uint16 num_files;
             uint32 archive_length;
             char signature2[4];
-        };
+        } sit_header_t;
     """
-    HEADER_STRUCT = "sit_header"
+    HEADER_STRUCT = "sit_header_t"
 
 
 class StuffIt5Handler(_StuffItHandlerBase):
@@ -78,7 +78,7 @@ class StuffIt5Handler(_StuffItHandlerBase):
     """
 
     C_DEFINITIONS = r"""
-        struct stuffit5_header
+        typedef struct stuffit5_header
         {
             char signature[80];
             uint32 unknown;
@@ -86,6 +86,6 @@ class StuffIt5Handler(_StuffItHandlerBase):
             uint32 entry_offset;
             uint16 num_root_dir_entries;
             uint32 first_entry_offset;
-        };
+        } stuffit5_header_t;
     """
-    HEADER_STRUCT = "stuffit5_header"
+    HEADER_STRUCT = "stuffit5_header_t"

--- a/unblob/handlers/archive/tar.py
+++ b/unblob/handlers/archive/tar.py
@@ -63,7 +63,7 @@ class TarHandler(StructHandler):
     YARA_MATCH_OFFSET = -MAGIC_OFFSET
 
     C_DEFINITIONS = r"""
-        struct posix_header
+        typedef struct posix_header
         {                       /* byte offset */
             char name[100];     /*   0 */
             char mode[8];       /* 100 */
@@ -82,9 +82,9 @@ class TarHandler(StructHandler):
             char devminor[8];   /* 337 */
             char prefix[155];   /* 345 */
                                 /* 500 */
-        };
+        } posix_header_t;
     """
-    HEADER_STRUCT = "posix_header"
+    HEADER_STRUCT = "posix_header_t"
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int

--- a/unblob/handlers/archive/zip.py
+++ b/unblob/handlers/archive/zip.py
@@ -30,13 +30,7 @@ class ZIPHandler(StructHandler):
     """
 
     C_DEFINITIONS = r"""
-        struct pk_generic
-        {
-            uint32 magic;
-            uint16 version;
-        }
-
-        struct local_file_header
+        typedef struct local_file_header
         {
             uint32 local_file_header_signature;
             uint16 version_needed_to_extract;
@@ -51,33 +45,9 @@ class ZIPHandler(StructHandler):
             uint16 extra_field_length;
             char file_name[file_name_length];
             char extra_field[extra_field_length];
-        }
+        } local_file_header_t;
 
-        struct central_directory_header
-        {
-            uint32 cd_header_signature; //
-            uint16 version_made_by;
-            uint16 min_version_to_extract;
-            uint16 gp_bitflag;
-            uint16 compression_method;
-            uint16 last_mod_file_time;
-            uint16 last_mod_file_date;
-            uint32 crc32;
-            uint32 compressed_size;
-            uint32 uncompressed_size;
-            uint16 file_name_length;
-            uint16 extra_field_length;
-            uint16 file_comment_length;
-            uint16 disk_number_start;
-            uint16 internal_file_attributes;
-            uint32 external_file_attributes;
-            uint32 offset_local_header;
-            char file_name[file_name_length];
-            char extra_field[extra_field_length];
-            char file_comment[file_comment_length];
-        }
-
-        struct end_of_central_directory
+        typedef struct end_of_central_directory
         {
             uint32 end_of_central_signature;
             uint16 disk_number;
@@ -88,17 +58,9 @@ class ZIPHandler(StructHandler):
             uint32 offset_of_cd;
             uint16 comment_len;
             char zip_file_comment[comment_len];
-        }
-
-        struct streaming_data
-        {
-            uint32 magic;
-            uint32 unk1;
-            uint32 unk2;
-            uint32 unk3;
-        }
+        } end_of_central_directory_t;
     """
-    HEADER_STRUCT = "local_file_header"
+    HEADER_STRUCT = "local_file_header_t"
 
     def _calculate_zipfile_end(self, file: io.BufferedIOBase, start_offset: int) -> int:
         # If we just pass a file with multiple ZIP files in it to zipfile.ZipFile, it seems
@@ -119,7 +81,7 @@ class ZIPHandler(StructHandler):
             raise MissingEOCDHeader
 
         file.seek(zip_end)
-        self.cparser_le.end_of_central_directory(file)
+        self.cparser_le.end_of_central_directory_t(file)
         return file.tell()
 
     def calculate_chunk(

--- a/unblob/handlers/compression/bzip2.py
+++ b/unblob/handlers/compression/bzip2.py
@@ -31,16 +31,16 @@ class BZip2Handler(StructHandler):
     """
 
     C_DEFINITIONS = r"""
-        struct bzip2_header {
+        typedef struct bzip2_header {
             char magic[2];              // 'BZ' signature/magic number
             uint8 version;              // 'h' for Bzip2 ('H'uffman coding), '0' for Bzip1 (deprecated)
             uint8 hundred_k_blocksize;  // '1'..'9' block-size 100 kB-900 kB (uncompressed)
             char compressed_magic[8];   // 0x314159265359 (BCD (pi))
             uint32 crc;                 // checksum for this block
             uint8 randomised;           // 0=>normal, 1=>randomised (deprecated)
-        };
+        } bzip2_header_t;
     """
-    HEADER_STRUCT = "bzip2_header"
+    HEADER_STRUCT = "bzip2_header_t"
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int

--- a/unblob/handlers/compression/lzh.py
+++ b/unblob/handlers/compression/lzh.py
@@ -37,7 +37,7 @@ class LZHHandler(StructHandler):
     )
 
     C_DEFINITIONS = r"""
-        struct lzh_default_header {
+        typedef struct lzh_default_header {
             uint8 header_size;          // excludes extended headers size
             uint8 header_checksum;
             char method_id[5];
@@ -46,9 +46,9 @@ class LZHHandler(StructHandler):
             uint32 timestamp;
             uint8 fd_attribute;
             uint8 level_identifier;
-        };
+        } lzh_default_header_t;
 
-        struct level_2_header {
+        typedef struct level_2_header {
             uint16 header_size; // includes all extended headers
             char method_id[5];
             uint32 compressed_size;     // excludes all extended headers
@@ -56,9 +56,9 @@ class LZHHandler(StructHandler):
             uint32 timestamp;
             uint8 fd_attribute;
             uint8 level_identifier;
-        };
+        } level_2_header_t;
     """
-    HEADER_STRUCT = "lzh_default_header"
+    HEADER_STRUCT = "lzh_default_header_t"
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int

--- a/unblob/handlers/compression/lzo.py
+++ b/unblob/handlers/compression/lzo.py
@@ -22,7 +22,7 @@ class LZOHandler(StructHandler):
     """
 
     C_DEFINITIONS = r"""
-        struct lzo_header_no_filter
+        typedef struct lzo_header_no_filter
         {
             char magic[9];
             uint16 version;
@@ -40,9 +40,9 @@ class LZOHandler(StructHandler):
             so we don't know what's the exact filename char array length
             at parsing time. Filename parsing is handled in calculate_chunk */
             //char filename[];
-        }
+        } lzo_header_no_filter_t;
 
-        struct lzo_header_filter
+        typedef struct lzo_header_filter
         {
             char magic[9];
             uint16 version;
@@ -60,15 +60,15 @@ class LZOHandler(StructHandler):
             so we don't know what's the exact filename char array length
             at parsing time. Filename parsing is handled in calculate_chunk */
             //char filename[];
-        }
+        } lzo_header_filter_t;
 
-        struct lzo_size_crc {
+        typedef struct lzo_size_crc {
             uint32 original_crc;        // (CRC32 if flags & F_H_CRC32 else Adler32)
             uint32 uncompressed_size;
             uint32 compressed_size;
             uint32 uncompressed_crc;
             uint32 compressed_crc;      // (only if flags & F_ADLER32_C or flags & F_CRC32_C)
-        }
+        } lzo_size_crc_t;
     """
     HEADER_STRUCT = "lzo_header"
 
@@ -76,16 +76,16 @@ class LZOHandler(StructHandler):
         self, file: io.BufferedIOBase, start_offset: int
     ) -> Optional[ValidChunk]:
 
-        header = self.cparser_be.lzo_header_no_filter(file)
+        header = self.cparser_be.lzo_header_no_filter_t(file)
 
         if header.flags & F_H_FILTER:
             file.seek(start_offset)
-            header = self.cparser_be.lzo_header_filter(file)
+            header = self.cparser_be.lzo_header_filter_t(file)
 
         file.seek(header.filename_len, io.SEEK_CUR)
         logger.debug("LZO header parsed", header=header)
 
-        size_crc_header = self.cparser_be.lzo_size_crc(file)
+        size_crc_header = self.cparser_be.lzo_size_crc_t(file)
         logger.debug("CRC header parsed", header=size_crc_header)
 
         end_offset = (

--- a/unblob/handlers/filesystem/cramfs.py
+++ b/unblob/handlers/filesystem/cramfs.py
@@ -23,7 +23,7 @@ class CramFSHandler(StructHandler):
     """
 
     C_DEFINITIONS = r"""
-        struct cramfs_header {
+        typedef struct cramfs_header {
             uint32 magic;
             uint32 size;
             uint32 flags;
@@ -34,9 +34,9 @@ class CramFSHandler(StructHandler):
             uint32 fsid_blocks;
             uint32 fsid_files;
             char name[16];
-        }
+        } cramfs_header_t;
     """
-    HEADER_STRUCT = "cramfs_header"
+    HEADER_STRUCT = "cramfs_header_t"
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int

--- a/unblob/handlers/filesystem/extfs.py
+++ b/unblob/handlers/filesystem/extfs.py
@@ -35,36 +35,36 @@ class EXTHandler(StructHandler):
     """
 
     C_DEFINITIONS = r"""
-        struct ext4_superblock {
-        char blank[0x400];              // Not a part of the spec. But we expect the magic to be at 0x438.
-        uint32 s_inodes_count;          // Total number of inodes in file system
-        uint32 s_blocks_count_lo;       // Total number of blocks in file system
-        uint32 s_r_blocks_count_lo;     // Number of blocks reserved for superuser (see offset 80)
-        uint32 s_free_blocks_count_lo;  // Total number of unallocated blocks
-        uint32 s_free_inodes_count;     // Total number of unallocated inodes
-        uint32 s_first_data_block;      // Block number of the block containing the superblock
-        uint32 s_log_block_size;        // log2 (block size) - 10  (In other words, the number to shift 1,024 to the left by to obtain the block size)
-        uint32 s_log_cluster_size;      // log2 (fragment size) - 10. (In other words, the number to shift 1,024 to the left by to obtain the fragment size)
-        uint32 s_blocks_per_group;      // Number of blocks in each block group
-        uint32 s_clusters_per_group;    // Number of fragments in each block group
-        uint32 s_inodes_per_group;      // Number of inodes in each block group
-        uint32 s_mtime;                 // Last mount time
-        uint32 s_wtime;                 // Last written time
-        uint16 s_mnt_count;             // Number of times the volume has been mounted since its last consistency check
-        uint16 s_max_mnt_count;         // Number of mounts allowed before a consistency check must be done
-        uint16 s_magic;                 // Ext signature (0xef53), used to help confirm the presence of Ext2 on a volume
-        uint16 s_state;                 // File system state (0x1 - clean or 0x2 - has errors)
-        uint16 s_errors;                // What to do when an error is detected (ignore/remount/kernel panic)
-        uint16 s_minor_rev_level;       // Minor portion of version (combine with Major portion below to construct full version field)
-        uint32 s_lastcheck;             // time of last consistency check
-        uint32 s_checkinterval;         // Interval between forced consistency checks
-        uint32 s_creator_os;            // Operating system ID from which the filesystem on this volume was created
-        uint32 s_rev_level;             // Major portion of version (combine with Minor portion above to construct full version field)
-        uint16 s_def_resuid;            // User ID that can use reserved blocks
-        uint16 s_def_resgid;            // Group ID that can use reserved blocks
-    }
+        typedef struct ext4_superblock {
+            char blank[0x400];              // Not a part of the spec. But we expect the magic to be at 0x438.
+            uint32 s_inodes_count;          // Total number of inodes in file system
+            uint32 s_blocks_count_lo;       // Total number of blocks in file system
+            uint32 s_r_blocks_count_lo;     // Number of blocks reserved for superuser (see offset 80)
+            uint32 s_free_blocks_count_lo;  // Total number of unallocated blocks
+            uint32 s_free_inodes_count;     // Total number of unallocated inodes
+            uint32 s_first_data_block;      // Block number of the block containing the superblock
+            uint32 s_log_block_size;        // log2 (block size) - 10  (In other words, the number to shift 1,024 to the left by to obtain the block size)
+            uint32 s_log_cluster_size;      // log2 (fragment size) - 10. (In other words, the number to shift 1,024 to the left by to obtain the fragment size)
+            uint32 s_blocks_per_group;      // Number of blocks in each block group
+            uint32 s_clusters_per_group;    // Number of fragments in each block group
+            uint32 s_inodes_per_group;      // Number of inodes in each block group
+            uint32 s_mtime;                 // Last mount time
+            uint32 s_wtime;                 // Last written time
+            uint16 s_mnt_count;             // Number of times the volume has been mounted since its last consistency check
+            uint16 s_max_mnt_count;         // Number of mounts allowed before a consistency check must be done
+            uint16 s_magic;                 // Ext signature (0xef53), used to help confirm the presence of Ext2 on a volume
+            uint16 s_state;                 // File system state (0x1 - clean or 0x2 - has errors)
+            uint16 s_errors;                // What to do when an error is detected (ignore/remount/kernel panic)
+            uint16 s_minor_rev_level;       // Minor portion of version (combine with Major portion below to construct full version field)
+            uint32 s_lastcheck;             // time of last consistency check
+            uint32 s_checkinterval;         // Interval between forced consistency checks
+            uint32 s_creator_os;            // Operating system ID from which the filesystem on this volume was created
+            uint32 s_rev_level;             // Major portion of version (combine with Minor portion above to construct full version field)
+            uint16 s_def_resuid;            // User ID that can use reserved blocks
+            uint16 s_def_resgid;            // Group ID that can use reserved blocks
+        } ext4_superblock_t;
     """
-    HEADER_STRUCT = "ext4_superblock"
+    HEADER_STRUCT = "ext4_superblock_t"
 
     YARA_MATCH_OFFSET = -MAGIC_OFFSET
 

--- a/unblob/handlers/filesystem/fat.py
+++ b/unblob/handlers/filesystem/fat.py
@@ -31,7 +31,7 @@ class FATHandler(StructHandler):
 
     C_DEFINITIONS = r"""
         // Common between FAT12, FAT16 and FAT32.
-        struct bios_param_common {
+        typedef struct bios_param_common {
             char JmpBoot[3];     // An x86 JMP - e.g. EB 3C 90 ("One finds either eb xx 90, or e9 xx xx.")
             char OEMName[8];     // OEM name/version (E.g. "IBM  3.3", "IBM 20.0", "MSDOS5.0", "MSWIN4.0".)
             // "BIOS Parameter Block" starts here
@@ -55,12 +55,11 @@ class FATHandler(StructHandler):
                                     // FATSz32 contains the FAT size count.
             uint16 SecPerTrk;   // Sectors per track for interrupt 0x13.
             uint16 NumHeads;    // Number of heads for interrupt 0x13
-        }
+        } bios_param_common_t;
 
         // BIOS params for FAT16.
-        struct fat12_16_bootsec {
-            bios_param_common common;
-
+        typedef struct fat12_16_bootsec {
+            bios_param_common_t common;
             uint32 NumHidden;
             uint32 NumSectors;
             uint8 DrvNum;
@@ -69,12 +68,11 @@ class FATHandler(StructHandler):
             char VolID[4];
             char VolLab[11];
             char FileSysType[8]; // Filesystem type (E.g. "FAT12   ", "FAT16   ", "FAT     ", or all zero.)
-        }
+        } fat12_16_bootsec_t;
 
         // BIOS params for FAT32.
-        struct fat32_bootsec {
-            bios_param_common common;
-
+        typedef struct fat32_bootsec {
+            bios_param_common_t common;
             uint32 Num_Hidden;
             uint32 TotSec32;
             uint32 FATSz32;
@@ -90,17 +88,17 @@ class FATHandler(StructHandler):
             char VolID[4];
             char VolLab[11];
             char FileSysType[8];
-        }
+        } fat32_bootsec_t;
 
-        struct fat_unknown {
-            bios_param_common common;
-        }
+        typedef struct fat_unknown {
+            bios_param_common_t common;
+        } fat_unknown_t;
     """
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int
     ) -> Optional[ValidChunk]:
-        header = self.cparser_le.fat12_16_bootsec(file)
+        header = self.cparser_le.fat12_16_bootsec_t(file)
         logger.debug("FAT header parsed", header=header)
 
         if header.FileSysType in (b"FAT12   ", b"FAT16   "):
@@ -118,7 +116,7 @@ class FATHandler(StructHandler):
         else:
             logger.debug("Assuming FAT32")
             file.seek(start_offset)
-            header = self.cparser_le.fat32_bootsec(file)
+            header = self.cparser_le.fat32_bootsec_t(file)
             logger.debug("FAT32 header parsed", header=header)
             sector_count = header.TotSec32
 

--- a/unblob/handlers/filesystem/iso9660.py
+++ b/unblob/handlers/filesystem/iso9660.py
@@ -52,7 +52,7 @@ class ISO9660FSHandler(StructHandler):
     """
 
     C_DEFINITIONS = r"""
-        struct iso9660_dtime_s {
+        typedef struct iso9660_dtime_s {
             uint8 dt_year;
             uint8 dt_month;
             uint8 dt_day;
@@ -62,7 +62,7 @@ class ISO9660FSHandler(StructHandler):
             int8 dt_gmtoff;
         } iso9660_dtime_t;
 
-        struct  iso9660_ltime_s {
+        typedef struct iso9660_ltime_s {
             char lt_year[4];
             char lt_month[2];
             char lt_day[2];
@@ -73,7 +73,7 @@ class ISO9660FSHandler(StructHandler):
             int8 lt_gmtoff;
         } iso9660_ltime_t;
 
-        struct iso9660_dir_s {
+        typedef struct iso9660_dir_s {
             uint8 length;
             uint8 xa_length;
             uint64 extent;
@@ -89,7 +89,7 @@ class ISO9660FSHandler(StructHandler):
             } filename;
         } iso9660_dir_t;
 
-        struct iso9660_pvd_s {
+        typedef struct iso9660_pvd_s {
             uint8         type;                         /**< ISO_VD_PRIMARY - 1 */
             char             id[5];                        /**< ISO_STANDARD_ID "CD001"
                                                             */
@@ -105,91 +105,6 @@ class ISO9660FSHandler(StructHandler):
             uint32         volume_set_size;              /**< often 1 */
             uint32         volume_sequence_number;       /**< often 1 */
             uint8         logical_block_size[4];           /**< sector size, e.g. 2048 */
-
-            // We don't need to parse any more from here, but keep it for future reference
-            // uint64         path_table_size;              /**< bytes in path table */
-            // uint32         type_l_path_table;            /**< first sector of L Path
-            //                                                     Table */
-            // uint32         opt_type_l_path_table;        /**< first sector of optional
-            //                                                 L Path Table */
-            // uint32         type_m_path_table;            /**< first sector of M Path
-            //                                                 table */
-            // uint32         opt_type_m_path_table;        /**< first sector of optional
-            //                                                 M Path table */
-            // iso9660_dir_t    root_directory_record;        /**< See 8.4.18 and
-            //                                                 section 9.1 of
-            //                                                 ISO 9660 spec. */
-            // char             root_directory_filename;      /**< Is '\\0' or root
-            //                                                 directory. Also pads previous
-            //                                                 field to 34 bytes */
-            // char          volume_set_id[128]; /**< Volume Set of
-            //                                                         which the volume is
-            //                                                         a member. See
-            //                                                     section 8.4.19 */
-            // char          publisher_id[128];  /**< Publisher of
-            //                                                     volume. If the first
-            //                                                     character is '_' 0x5F,
-            //                                                     the remaining bytes
-            //                                                     specify a file
-            //                                                     containing the user.
-            //                                                     If all bytes are " "
-            //                                                     (0x20) no publisher
-            //                                                     is specified. See
-            //                                                     section 8.4.20 of
-            //                                                     ECMA 119 */
-            // char          preparer_id[128]; /**< preparer of
-            //                                                     volume. If the first
-            //                                                     character is '_' 0x5F,
-            //                                                     the remaining bytes
-            //                                                     specify a file
-            //                                                     containing the user.
-            //                                                     If all bytes are " "
-            //                                                     (0x20) no preparer
-            //                                                     is specified.
-            //                                                     See section 8.4.21
-            //                                                     of ECMA 119 */
-            // char          application_id[128]; /**< application
-            //                                                     use to create the
-            //                                                     volume. If the first
-            //                                                     character is '_' 0x5F,
-            //                                                     the remaining bytes
-            //                                                     specify a file
-            //                                                     containing the user.
-            //                                                     If all bytes are " "
-            //                                                     (0x20) no application
-            //                                                     is specified.
-            //                                                     See section of 8.4.22
-            //                                                     of ECMA 119 */
-            // char          copyright_file_id[37];     /**< Name of file for
-            //                                             copyright info. If
-            //                                             all bytes are " "
-            //                                             (0x20), then no file
-            //                                             is identified.  See
-            //                                             section 8.4.23 of ECMA 119
-            //                                             9660 spec. */
-            // char          abstract_file_id[37];      /**< See section 8.4.24 of
-            //                                             ECMA 119. */
-            // char          bibliographic_file_id[37]; /**< See section 7.5 of
-            //                                             ISO 9660 spec. */
-            // iso9660_ltime_t  creation_date;             /**< date and time of volume
-            //                                             creation. See section 8.4.26.1
-            //                                             of the ISO 9660 spec. */
-            // iso9660_ltime_t  modification_date;         /**< date and time of the most
-            //                                             recent modification.
-            //                                             See section 8.4.27 of the
-            //                                             ISO 9660 spec. */
-            // iso9660_ltime_t  expiration_date;           /**< date and time when volume
-            //                                             expires. See section 8.4.28
-            //                                             of the ISO 9660 spec. */
-            // iso9660_ltime_t  effective_date;            /**< date and time when volume
-            //                                             is effective. See section
-            //                                             8.4.29 of the ISO 9660
-            //                                             spec. */
-            // uint8         file_structure_version;    /**< value 1 for ECMA 119 */
-            // uint8           unused4[1];                /**< unused - value 0 */
-            // char             application_data[512];     /**< Application can put
-            //                                             whatever it wants here. */
-            // uint8          unused5[653];              /**< Unused - value 0 */
         } iso9660_pvd_t;
     """
 

--- a/unblob/handlers/filesystem/jffs2.py
+++ b/unblob/handlers/filesystem/jffs2.py
@@ -36,10 +36,9 @@ class _JFFS2Base(StructHandler):
     C_DEFINITIONS = r"""
         typedef struct jffs2_unknown_node
         {
-            /* All start like this */
             uint16 magic;
             uint16 nodetype;
-            uint32 totlen; /* So we can skip over nodes we don't grok */
+            uint32 totlen;
             uint32 hdr_crc;
         } jffs2_unknown_node_t;
     """

--- a/unblob/handlers/filesystem/squashfs.py
+++ b/unblob/handlers/filesystem/squashfs.py
@@ -40,7 +40,7 @@ class SquashFSv3Handler(_SquashFSBase):
     """
 
     C_DEFINITIONS = r"""
-        struct SQUASHFS3_SUPER_BLOCK
+        typedef struct squashfs3_super_block
         {
             char   s_magic[4];
             uint32 inodes;
@@ -68,9 +68,9 @@ class SquashFSv3Handler(_SquashFSBase):
             int64  directory_table_start;
             int64  fragment_table_start;
             int64  lookup_table_start;
-        };
+        } squashfs3_super_block_t;
     """
-    HEADER_STRUCT = "SQUASHFS3_SUPER_BLOCK"
+    HEADER_STRUCT = "squashfs3_super_block_t"
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int
@@ -101,7 +101,7 @@ class SquashFSv4Handler(_SquashFSBase):
     """
 
     C_DEFINITIONS = r"""
-        struct SQUASHFS4_SUPER_BLOCK
+        typedef struct squashfs4_super_block
         {
             char   s_magic[4];
             uint32 inodes;
@@ -122,9 +122,9 @@ class SquashFSv4Handler(_SquashFSBase):
             int64  directory_table_start;
             int64  fragment_table_start;
             int64  lookup_table_start;
-        };
+        } squashfs4_super_block_t;
     """
-    HEADER_STRUCT = "SQUASHFS4_SUPER_BLOCK"
+    HEADER_STRUCT = "squashfs4_super_block_t"
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int

--- a/unblob/handlers/filesystem/ubi.py
+++ b/unblob/handlers/filesystem/ubi.py
@@ -36,58 +36,50 @@ class UBIFSHandler(StructHandler):
     """
 
     C_DEFINITIONS = r"""
-        typedef uint64 __le64;
-        typedef uint32 __le32;
-        typedef uint16 __le16;
-        typedef uint8 __u8;
+        typedef struct ubifs_ch {
+            uint32 magic;
+            uint32 crc;
+            uint64 sqnum;
+            uint32 len;
+            uint8 node_type;
+            uint8 group_type;
+            uint8 padding[2];
+        } ubifs_ch_t;
 
-        #define UBIFS_MAX_HASH_LEN 64
-        #define UBIFS_MAX_HMAC_LEN 64
-
-        struct ubifs_ch {
-            __le32 magic;
-            __le32 crc;
-            __le64 sqnum;
-            __le32 len;
-            __u8 node_type;
-            __u8 group_type;
-            __u8 padding[2];
-        };
-
-        struct ubifs_sb_node {
-            struct ubifs_ch ch;
-            __u8 padding[2];
-            __u8 key_hash;
-            __u8 key_fmt;
-            __le32 flags;
-            __le32 min_io_size;
-            __le32 leb_size;
-            __le32 leb_cnt;
-            __le32 max_leb_cnt;
-            __le64 max_bud_bytes;
-            __le32 log_lebs;
-            __le32 lpt_lebs;
-            __le32 orph_lebs;
-            __le32 jhead_cnt;
-            __le32 fanout;
-            __le32 lsave_cnt;
-            __le32 fmt_version;
-            __le16 default_compr;
-            __u8 padding1[2];
-            __le32 rp_uid;
-            __le32 rp_gid;
-            __le64 rp_size;
-            __le32 time_gran;
-            __u8 uuid[16];
-            __le32 ro_compat_version;
-            __u8 hmac[UBIFS_MAX_HMAC_LEN];
-            __u8 hmac_wkm[UBIFS_MAX_HMAC_LEN];
-            __le16 hash_algo;
-            __u8 hash_mst[UBIFS_MAX_HASH_LEN];
-            __u8 padding2[3774];
-        };
+        typedef struct ubifs_sb_node {
+            ubifs_ch_t ch;
+            uint8 padding[2];
+            uint8 key_hash;
+            uint8 key_fmt;
+            uint32 flags;
+            uint32 min_io_size;
+            uint32 leb_size;
+            uint32 leb_cnt;
+            uint32 max_leb_cnt;
+            uint64 max_bud_bytes;
+            uint32 log_lebs;
+            uint32 lpt_lebs;
+            uint32 orph_lebs;
+            uint32 jhead_cnt;
+            uint32 fanout;
+            uint32 lsave_cnt;
+            uint32 fmt_version;
+            uint16 default_compr;
+            uint8 padding1[2];
+            uint32 rp_uid;
+            uint32 rp_gid;
+            uint64 rp_size;
+            uint32 time_gran;
+            uint8 uuid[16];
+            uint32 ro_compat_version;
+            uint8 hmac[64];
+            uint8 hmac_wkm[64];
+            uint16 hash_algo;
+            uint8 hash_mst[64];
+            uint8 padding2[3774];
+        } ubifs_sb_node_t;
     """
-    HEADER_STRUCT = "ubifs_sb_node"
+    HEADER_STRUCT = "ubifs_sb_node_t"
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int


### PR DESCRIPTION
Fix #128 by normalizing C struct convention of every C_DEFINITIONS entry (no uppercase type names, standard C11 data types and types definition with typedef struct).