### PR TITLE
Fix uncaught encoding errors.

### DIFF
--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,4 +1,5 @@
 import io
+from pathlib import Path
 from typing import List
 from unittest.mock import MagicMock
 
@@ -20,6 +21,7 @@ from unblob.file_utils import (
     iterate_patterns,
     round_down,
     round_up,
+    valid_path,
 )
 
 
@@ -430,3 +432,16 @@ class TestGetEndian:
         with pytest.raises(InvalidInputFormat):
             get_endian(file, 0xFFFF_0000)
         assert file.tell() == pos
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    (
+        pytest.param("some_random_file.txt", True, id="valid_unicode_path"),
+        pytest.param(
+            "some/random/file\udce4\udc94.txt", False, id="invalid_unicode_path"
+        ),
+    ),
+)
+def test_valid_path(content: str, expected: bool):
+    assert valid_path(Path(content)) == expected

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -26,11 +26,11 @@ def test_format_message_dont_care_root_path(value: Any, expected: str):
 @pytest.mark.parametrize(
     "value, extract_root, expected",
     (
-        (Path("/a/b/c"), Path("/"), "a/b/c"),
-        (Path("/a/b/c"), Path("/a/b"), "c"),
-        (Path("/a/b/c"), Path(""), "/a/b/c"),
-        (Path("/a/b/c"), Path("qwe"), "/a/b/c"),
-        (Path("/a/b/c"), Path("/q/w/e"), "/a/b/c"),
+        (Path("/a/b/c"), Path("/"), b"a/b/c"),
+        (Path("/a/b/c"), Path("/a/b"), b"c"),
+        (Path("/a/b/c"), Path(""), b"/a/b/c"),
+        (Path("/a/b/c"), Path("qwe"), b"/a/b/c"),
+        (Path("/a/b/c"), Path("/q/w/e"), b"/a/b/c"),
     ),
 )
 def test_format_message_root_path(value: Path, extract_root: Path, expected: str):

--- a/unblob/extractor.py
+++ b/unblob/extractor.py
@@ -58,11 +58,19 @@ def extract_with_command(
     logger.info("Running extract command", command=shlex.join(cmd))
     try:
         res = subprocess.run(
-            cmd, encoding="utf-8", stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            cmd,
+            encoding="utf-8",
+            errors="surrogateescape",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
         if res.returncode != 0:
             exit_code_var.set(1)
-            logger.error("Extract command failed", stdout=res.stdout, stderr=res.stderr)
+            logger.error(
+                "Extract command failed",
+                stdout=res.stdout.encode("utf-8", errors="surrogateescape"),
+                stderr=res.stderr.encode("utf-8", errors="surrogateescape"),
+            )
 
         fix_permissions(outdir)
     except FileNotFoundError:

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -4,6 +4,7 @@ import math
 import os
 import shutil
 import struct
+from pathlib import Path
 from typing import Iterator, Tuple
 
 from dissect.cstruct import cstruct
@@ -287,3 +288,11 @@ def read_until_past(file: io.BufferedIOBase, pattern: bytes):
             return file.tell()
         if next_byte not in pattern:
             return file.tell() - 1
+
+
+def valid_path(path: Path) -> bool:
+    try:
+        path.as_posix().encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return True

--- a/unblob/finder.py
+++ b/unblob/finder.py
@@ -138,7 +138,7 @@ def search_yara_patterns(
 ) -> List[YaraMatchResult]:
     """Search with the compiled YARA rules and identify the handler which defined the rule."""
     # YARA uses a memory mapped file internally when given a path
-    yara_matches: List[yara.Match] = yara_rules.match(str(full_path), timeout=60)
+    yara_matches: List[yara.Match] = yara_rules.match(full_path.as_posix(), timeout=60)
 
     yara_results = []
     for match in yara_matches:

--- a/unblob/logging.py
+++ b/unblob/logging.py
@@ -31,10 +31,11 @@ def _format_message(value: Any, extract_root: Path) -> Any:
 
     elif isinstance(value, Path):
         try:
-            return str(value.relative_to(extract_root))
+            new_value = value.relative_to(extract_root)
         except ValueError:
             # original files given to unblob may not be relative to extract_root
-            return str(value)
+            new_value = value
+        return new_value.as_posix().encode("utf-8", errors="surrogateescape")
 
     elif isinstance(value, Instance):
         return dumpstruct(value, output="string")

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -10,7 +10,7 @@ import plotext as plt
 from structlog import get_logger
 
 from .extractor import carve_unknown_chunks, extract_valid_chunk, make_extract_dir
-from .file_utils import iterate_file
+from .file_utils import iterate_file, valid_path
 from .finder import search_chunks_by_priority
 from .iter_utils import pairwise
 from .logging import multiprocessing_breakpoint, noformat
@@ -101,6 +101,10 @@ def _process_task(  # noqa: C901
     log = logger.bind(path=task.path)
     if task.depth >= config.max_depth:
         log.info("Reached maximum depth, stop further processing")
+        return
+
+    if not valid_path(task.path):
+        log.warn("Path contains invalid characters, it won't be processed")
         return
 
     log.info("Start processing file")


### PR DESCRIPTION
A few encoding errors were identified during the initial fuzzing campaigns. This commit fix these errors at multiple locations.
    
#### Logging
- pathlib.Path are represented as POSIX path encoded as utf-8 using surrogateescape in case of encoding error.
- str values are encoded as utf-8 using surrogateescape in case of encoding error.

Test cases were modified accordingly.
    
#### Extraction
subprocess calls output (stderr, stdout) are now encoded as utf-8 using surrogateescape in case of encoding error.
    
#### Processing

path provided to process_file are checked for potential encoding error. If an error is triggered, the file won't be processed.
    
Path triggering encoding errors are not processed because, even if they can be printed out in logs, they are not properly handled by yara-python. We took this decision because encoding errors like these only arise on badly corrupted files, or specifically crafted malicious files.
    
These fixes relates to issues #186 and #184. This commit fixes both as they both relates to encoding errors triggered by corrupted files.