### PR TITLE
Fix path traversal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ attrs = "^21.2.0"
 structlog = "^21.2.0"
 arpy = "^2.2.0"
 rarfile = "^4.0"
-ubi-reader = "^0.7.0"
+ubi-reader = { git = "https://github.com/IoT-Inspector/ubi_reader.git", rev = "3b30234ffe117eb3d4f2a7a4e455c3fb4bca3668" }
 python-lzo = "^1.12"
 cstruct = "2.1"
 jefferson = { git = "https://github.com/IoT-Inspector/jefferson.git", rev = "41f654eac078cfec240428be457c054613a80851" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,10 @@ rarfile = "^4.0"
 ubi-reader = "^0.7.0"
 python-lzo = "^1.12"
 cstruct = "2.1"
-jefferson = { git = "https://github.com/IoT-Inspector/jefferson.git", rev = "216eee6c56d338e5a14a0af5d07f1117cff92b3b" }
+jefferson = { git = "https://github.com/IoT-Inspector/jefferson.git", rev = "41f654eac078cfec240428be457c054613a80851" }
 yaffshiv = { git = "https://github.com/IoT-Inspector/yaffshiv.git", rev = "24e6e453a36a02144ae2d159eb3229f9c6312828" }
 plotext = "^4.1.5"
+
 
 [tool.poetry.dev-dependencies]
 lark = "^1.0.0"

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple1.txt
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple2.txt
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple3.txt
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple4.txt
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/apple.gnu.tar
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/apple.gnu.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:704b918a3576c1e6264d416fbd032915312e063217bc022686535934955dc6d3
+size 90

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/apple.posix.tar
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/apple.posix.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44e00dac9ab50ac634dbf3048a69da7fd267cd804d6c95eafafeaad72c4861b5
+size 90

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana1.txt
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f3c13f738ccea4feb19070fa4da4f23b11742034aa5c886ba91d6b3002af6d
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana2.txt
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f3c13f738ccea4feb19070fa4da4f23b11742034aa5c886ba91d6b3002af6d
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana3.txt
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f3c13f738ccea4feb19070fa4da4f23b11742034aa5c886ba91d6b3002af6d
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana4.txt
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f3c13f738ccea4feb19070fa4da4f23b11742034aa5c886ba91d6b3002af6d
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple1.txt
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple2.txt
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple3.txt
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple4.txt
+++ b/tests/integration/archive/tar/__output__/cherry.gnu.tar_extract/0-81920.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/PaxHeaders/banana.gnu.tar
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/PaxHeaders/banana.gnu.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04082fbca0b5679f929fe7df0f5091769eae83599bb90c2c3e5b5e2207cacc8c
+size 90

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/PaxHeaders/banana.posix.tar
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/PaxHeaders/banana.posix.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04082fbca0b5679f929fe7df0f5091769eae83599bb90c2c3e5b5e2207cacc8c
+size 90

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/PaxHeaders/cherry1.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/PaxHeaders/cherry1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d7b88923b42ae578e58a3fffb4c69e005797f068db57c4933e118c828d2fd8c
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/PaxHeaders/cherry2.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/PaxHeaders/cherry2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89ab6beecb83217fe1a9447aebe43c271e1a1bd67fc68c26d4405fe3d74ed779
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/PaxHeaders/cherry3.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/PaxHeaders/cherry3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b84387281b7e421c0c9c5393c9c7c734f344937e650f4df545cbaeed8d54c34f
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/PaxHeaders/cherry4.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/PaxHeaders/cherry4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfed32bec0e8535f0259ab7f84f5647bb5704dc236fcd1919ef8ad3fdcc8c498
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple1.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple2.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple3.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple4.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.gnu.tar_extract/0-30720.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/apple.gnu.tar
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/apple.gnu.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:704b918a3576c1e6264d416fbd032915312e063217bc022686535934955dc6d3
+size 90

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/apple.posix.tar
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/apple.posix.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44e00dac9ab50ac634dbf3048a69da7fd267cd804d6c95eafafeaad72c4861b5
+size 90

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana1.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f3c13f738ccea4feb19070fa4da4f23b11742034aa5c886ba91d6b3002af6d
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana2.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f3c13f738ccea4feb19070fa4da4f23b11742034aa5c886ba91d6b3002af6d
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana3.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f3c13f738ccea4feb19070fa4da4f23b11742034aa5c886ba91d6b3002af6d
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana4.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/PaxHeaders/banana4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f3c13f738ccea4feb19070fa4da4f23b11742034aa5c886ba91d6b3002af6d
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple1.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple2.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple3.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple4.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posix.tar_extract/0-92160.tar_extract/banana.posix.tar_extract/0-40960.tar_extract/apple.posix.tar_extract/0-10240.tar_extract/PaxHeaders/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77aa67378f7a28dd2a62b798405edc813d0c4613c4232fd6d2830886caa46b06
+size 60

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,7 +1,14 @@
 import io
-from pathlib import Path
+from pathlib import Path, PosixPath
 
-from unblob.extractor import carve_unknown_chunks
+import pytest
+
+from unblob.extractor import (
+    carve_unknown_chunks,
+    fix_extracted_directory,
+    fix_permission,
+    fix_symlink,
+)
 from unblob.models import UnknownChunk
 
 
@@ -30,3 +37,163 @@ class TestCarveUnknownChunks:
         assert sorted(tmp_path.iterdir()) == [written_path1, written_path2]
         assert written_path1.read_bytes() == content[:4]
         assert written_path2.read_bytes() == content[4:]
+
+
+def test_fix_permission(tmpdir: Path):
+    tmpdir = PosixPath(tmpdir)
+    tmpfile = PosixPath(tmpdir / "file.txt")
+    tmpfile.touch()
+    tmpdir.chmod(0o777)
+    tmpfile.chmod(0o777)
+    fix_permission(tmpdir)
+    fix_permission(tmpfile)
+    assert (tmpdir.stat().st_mode & 0o777) == 0o775
+    assert (tmpfile.stat().st_mode & 0o777) == 0o644
+
+
+def test_fix_extracted_directory(tmpdir: Path):
+    tmpdir = PosixPath(tmpdir)
+    subdir = PosixPath(tmpdir / "testdir2")
+    subdir.mkdir()
+    tmpfile = PosixPath(subdir / "file.txt")
+    tmpfile.touch()
+
+    tmpfile.chmod(0o200)
+    subdir.chmod(0o200)
+    tmpdir.chmod(0o200)
+
+    fix_extracted_directory(tmpdir)
+    assert (tmpdir.stat().st_mode & 0o777) == 0o775
+    assert (subdir.stat().st_mode & 0o777) == 0o775
+    assert (tmpfile.stat().st_mode & 0o777) == 0o644
+
+
+def test_fix_recursive_symlink(tmpdir: Path):
+
+    tmpdir = PosixPath(tmpdir)
+    link_path = tmpdir / Path("link_a")
+    second_link_path = tmpdir / Path("link_b")
+    link_path.symlink_to("link_b")
+    second_link_path.symlink_to("link_a")
+
+    fixed_link = fix_symlink(link_path, tmpdir)
+    assert fixed_link.exists() is False
+
+
+def test_fix_symlink_chain(tmpdir: Path):
+
+    tmpdir = PosixPath(tmpdir)
+    link_path = tmpdir / Path("link_a")
+
+    target_path = Path(".")
+    link_path.symlink_to(target_path)
+
+    fixed_link = fix_symlink(link_path, tmpdir)
+    assert fixed_link.resolve() == tmpdir
+
+
+def test_fix_symlink_chain_traversal(tmpdir: Path):
+
+    tmpdir = PosixPath(tmpdir)
+    link_path = tmpdir / Path("link_a")
+
+    target_path = Path("..")
+    link_path.symlink_to(target_path)
+
+    fixed_link = fix_symlink(link_path, tmpdir)
+    assert fixed_link.exists() is False
+
+
+@pytest.mark.parametrize(
+    "link, target, expected",
+    (
+        ("link_a", "/etc/passwd", "etc/passwd"),
+        ("link_b", "etc/passwd", "etc/passwd"),
+        ("link_c", "target_c", "target_c"),
+        ("link_d", "/tmp/out/test/../../target_d", "tmp/target_d"),
+    ),
+)
+def test_fix_symlink(link: str, target: str, expected: str, tmpdir: Path):
+
+    tmpdir = PosixPath(tmpdir)
+    link_path = tmpdir / Path(link)
+    expected_link = tmpdir / Path(expected)
+    target_path = Path(target)
+
+    link_path.symlink_to(target_path)
+
+    fixed_link = fix_symlink(link_path, tmpdir)
+    assert fixed_link.resolve() == expected_link
+
+
+@pytest.mark.parametrize(
+    "link, target, expected",
+    (
+        ("dir_1/link_a", "../target_a", "../target_a"),
+        ("dir_1/link_b", "target_b", "target_b"),
+        ("dir_1/link_c", "../dir_1/target_c", "target_c"),
+        ("dir_1/dir_2/link_d", "../../target_d", "../../target_d"),
+        ("dir_1/dir_2/link_e", "../target_e", "../target_e"),
+        ("dir_1/dir_2/dir_3/link_f", "../../../target_f", "../../../target_f"),
+        ("dir_1/dir_2/dir_3/link_g", "../../dir_2/target_g", "../../dir_2/target_g"),
+        ("dir_1/dir_2/dir_3/link_h", "../dir_1/target_h", "../dir_1/target_h"),
+        ("dir_1/link_i", "/etc/passwd", "../etc/passwd"),
+    ),
+)
+def test_fix_symlink_subdir(link: str, target: str, expected: str, tmpdir: Path):
+
+    tmpdir = PosixPath(tmpdir)
+    link_path = tmpdir / Path(link)
+    expected_link = Path(expected)
+    target_path = Path(target)
+
+    link_path.parent.mkdir(parents=True, exist_ok=True)
+    link_path.symlink_to(target_path)
+
+    fixed_link = fix_symlink(link_path, tmpdir)
+    assert fixed_link.resolve() == link_path.parent.joinpath(expected_link).resolve()
+
+
+@pytest.mark.parametrize(
+    "link, target",
+    (
+        ("link_a", "../target_a"),
+        ("link_b", "../../target_b"),
+        ("link_c", "../../../target_c"),
+        ("link_d", "../../../../target_d"),
+        ("link_e", "../../../../../target_e"),
+        ("link_f", "/tmp/../../target_f"),
+        ("link_g", "/tmp/out/../../../target_g"),
+    ),
+)
+def test_fix_symlink_traversal(link: str, target: str, tmpdir: Path):
+
+    tmpdir = PosixPath(tmpdir)
+    link_path = tmpdir / Path(link)
+    target_path = Path(target)
+
+    link_path.symlink_to(target_path)
+
+    fixed_link = fix_symlink(link_path, tmpdir)
+    assert fixed_link.exists() is False
+
+
+@pytest.mark.parametrize(
+    "link, target",
+    (
+        ("dir_1/link_a", "../../target_a"),
+        ("dir_1/dir_2/link_b", "../../../target_b"),
+        ("dir_1/dir_2/dir_3/link_f", "../../../../target_f"),
+    ),
+)
+def test_fix_symlink_traversal_subdir(link: str, target: str, tmpdir: Path):
+
+    tmpdir = PosixPath(tmpdir)
+    link_path = tmpdir / Path(link)
+    target_path = Path(target)
+
+    link_path.parent.mkdir(parents=True, exist_ok=True)
+    link_path.symlink_to(target_path)
+
+    fixed_link = fix_symlink(link_path, tmpdir)
+    assert fixed_link.exists() is False

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -9,7 +9,7 @@ from unblob.extractor import (
     fix_permission,
     fix_symlink,
 )
-from unblob.models import UnknownChunk
+from unblob.models import TaskResult, UnknownChunk
 
 
 class TestCarveUnknownChunks:
@@ -62,7 +62,7 @@ def test_fix_extracted_directory(tmpdir: Path):
     subdir.chmod(0o200)
     tmpdir.chmod(0o200)
 
-    fix_extracted_directory(tmpdir)
+    fix_extracted_directory(tmpdir, TaskResult())
     assert (tmpdir.stat().st_mode & 0o777) == 0o775
     assert (subdir.stat().st_mode & 0o777) == 0o775
     assert (tmpfile.stat().st_mode & 0o777) == 0o644
@@ -76,7 +76,7 @@ def test_fix_recursive_symlink(tmpdir: Path):
     link_path.symlink_to("link_b")
     second_link_path.symlink_to("link_a")
 
-    fixed_link = fix_symlink(link_path, tmpdir)
+    fixed_link = fix_symlink(link_path, tmpdir, TaskResult())
     assert fixed_link.exists() is False
 
 
@@ -88,7 +88,7 @@ def test_fix_symlink_chain(tmpdir: Path):
     target_path = Path(".")
     link_path.symlink_to(target_path)
 
-    fixed_link = fix_symlink(link_path, tmpdir)
+    fixed_link = fix_symlink(link_path, tmpdir, TaskResult())
     assert fixed_link.resolve() == tmpdir
 
 
@@ -100,7 +100,7 @@ def test_fix_symlink_chain_traversal(tmpdir: Path):
     target_path = Path("..")
     link_path.symlink_to(target_path)
 
-    fixed_link = fix_symlink(link_path, tmpdir)
+    fixed_link = fix_symlink(link_path, tmpdir, TaskResult())
     assert fixed_link.exists() is False
 
 
@@ -122,7 +122,7 @@ def test_fix_symlink(link: str, target: str, expected: str, tmpdir: Path):
 
     link_path.symlink_to(target_path)
 
-    fixed_link = fix_symlink(link_path, tmpdir)
+    fixed_link = fix_symlink(link_path, tmpdir, TaskResult())
     assert fixed_link.resolve() == expected_link
 
 
@@ -150,7 +150,7 @@ def test_fix_symlink_subdir(link: str, target: str, expected: str, tmpdir: Path)
     link_path.parent.mkdir(parents=True, exist_ok=True)
     link_path.symlink_to(target_path)
 
-    fixed_link = fix_symlink(link_path, tmpdir)
+    fixed_link = fix_symlink(link_path, tmpdir, TaskResult())
     assert fixed_link.resolve() == link_path.parent.joinpath(expected_link).resolve()
 
 
@@ -174,7 +174,7 @@ def test_fix_symlink_traversal(link: str, target: str, tmpdir: Path):
 
     link_path.symlink_to(target_path)
 
-    fixed_link = fix_symlink(link_path, tmpdir)
+    fixed_link = fix_symlink(link_path, tmpdir, TaskResult())
     assert fixed_link.exists() is False
 
 
@@ -195,5 +195,5 @@ def test_fix_symlink_traversal_subdir(link: str, target: str, tmpdir: Path):
     link_path.parent.mkdir(parents=True, exist_ok=True)
     link_path.symlink_to(target_path)
 
-    fixed_link = fix_symlink(link_path, tmpdir)
+    fixed_link = fix_symlink(link_path, tmpdir, TaskResult())
     assert fixed_link.exists() is False

--- a/unblob/extractor.py
+++ b/unblob/extractor.py
@@ -12,7 +12,7 @@ from structlog import get_logger
 
 from .file_utils import iterate_file
 from .models import Chunk, Handler, TaskResult, UnknownChunk, ValidChunk
-from .report import ExtractCommandFailedReport
+from .report import ExtractCommandFailedReport, MaliciousSymlinkRemoved
 
 logger = get_logger()
 
@@ -60,7 +60,7 @@ def is_recursive_link(path: Path) -> bool:
         return True
 
 
-def fix_symlink(path: Path, outdir: Path) -> Path:
+def fix_symlink(path: Path, outdir: Path, task_result: TaskResult) -> Path:
     """Fix symlinks by rewriting absolute symlinks to make them point within
     the extraction directory (outdir), if it's not a relative symlink it is
     either removed it it attempts to traverse outside of the extraction directory
@@ -69,6 +69,10 @@ def fix_symlink(path: Path, outdir: Path) -> Path:
 
     if is_recursive_link(path):
         logger.error(f"Symlink loop identified, removing {path}.")
+        error_report = MaliciousSymlinkRemoved(
+            link=path.as_posix(), target=os.readlink(path)
+        )
+        task_result.add_report(error_report)
         path.unlink()
         return path
 
@@ -83,6 +87,10 @@ def fix_symlink(path: Path, outdir: Path) -> Path:
 
     if not safe:
         logger.error(f"Path traversal attempt through symlink, removing {target}.")
+        error_report = MaliciousSymlinkRemoved(
+            link=path.as_posix(), target=target.as_posix()
+        )
+        task_result.add_report(error_report)
         path.unlink()
     else:
         relative_target = os.path.relpath(outdir.joinpath(target), start=path.parent)
@@ -91,11 +99,11 @@ def fix_symlink(path: Path, outdir: Path) -> Path:
     return path
 
 
-def fix_extracted_directory(outdir: Path):
+def fix_extracted_directory(outdir: Path, task_result: TaskResult):
     fix_permission(outdir)
     for path in outdir.rglob("*"):
         if path.is_symlink():
-            fix_symlink(path, outdir)
+            fix_symlink(path, outdir, task_result)
         else:
             fix_permission(path)
 
@@ -138,7 +146,7 @@ def extract_with_command(
             task_result.add_report(error_report)
             logger.error("Extract command failed", **error_report.asdict())
 
-        fix_extracted_directory(outdir)
+        fix_extracted_directory(outdir, task_result)
     except FileNotFoundError:
         logger.error(
             "Can't run extract command. Is the extractor installed?",

--- a/unblob/handlers/archive/tar.py
+++ b/unblob/handlers/archive/tar.py
@@ -115,4 +115,4 @@ class TarHandler(StructHandler):
 
     @staticmethod
     def make_extract_command(inpath: str, outdir: str) -> List[str]:
-        return ["tar", "xvf", inpath, "--directory", outdir]
+        return ["7z", "x", inpath, f"-o{outdir}"]

--- a/unblob/report.py
+++ b/unblob/report.py
@@ -30,9 +30,17 @@ class CalculateChunkExceptionReport(UnknownError):
 
 @attr.define(kw_only=True)
 class ExtractCommandFailedReport(Report):
-    """Describes an error when failed to run the exctraction command"""
+    """Describes an error when failed to run the extraction command"""
 
     command: str
     stdout: bytes
     stderr: bytes
     exit_code: int
+
+
+@attr.define(kw_only=True)
+class MaliciousSymlinkRemoved(Report):
+    """Describes an error when malicious symlinks have been removed from disk."""
+
+    link: str
+    target: str


### PR DESCRIPTION
Attempt to fix all potential issues due to path traversal identified in https://github.com/IoT-Inspector/unblob/issues/179

Will be kept as draft until we manage to fix all these:

- [x] replace tar extractor by 7z extractor in tar handler
- [x] fix unromfs extractor path traversal (see https://github.com/IoT-Inspector/unblob/pull/163)
- [x] fix unromfs extractor link path traversal (see https://github.com/IoT-Inspector/unblob/pull/163)
- [x] fix ubireader_extract_files path traversal (see https://github.com/IoT-Inspector/ubi_reader/commit/3b30234ffe117eb3d4f2a7a4e455c3fb4bca3668)
- [x] fix ubireader_extract_files link path traversal (fixed within unblob)
- [x] fix jefferson path traversal (see https://github.com/IoT-Inspector/jefferson/commit/41f654eac078cfec240428be457c054613a80851)
- [x] fix jefferson link path traversal (fixed within unblob)
- [x] fix unar link traversal (fixed within unblob)
- [x] fix unsquashfs link traversal (fixed within unblob)
- [x] write an integration test suite for symlink fixup function


While path traversal is a real issue that should be fixed in our 3rd party extractors, link based traversal is only problematic in platforms like ours. Instead of fixing link based traversals in 3rd party extractors, we should rather do it in unblob once files have been extracted.