### PR TITLE
Fix error handling for malformed chunks.

### DIFF
--- a/tests/handlers/compression/test_compress.py
+++ b/tests/handlers/compression/test_compress.py
@@ -2,6 +2,7 @@ import io
 
 import pytest
 
+from unblob.file_utils import InvalidInputFormat
 from unblob.handlers.compression.compress import UnixCompressHandler
 
 
@@ -51,5 +52,5 @@ def test_unlzw(content: bytes, start_offset: int, expected_end_offset: int):
 def test_unlzw_errors(content: bytes, start_offset: int):
     handler = UnixCompressHandler()
     fake_file = io.BytesIO(content)
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidInputFormat):
         handler.unlzw(fake_file, start_offset, max_len=len(content))

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -6,6 +6,7 @@ import pytest
 
 from unblob.file_utils import (
     Endian,
+    InvalidInputFormat,
     LimitedStartReader,
     StructParser,
     convert_int8,
@@ -148,7 +149,7 @@ class TestConvertInt8:
         ),
     )
     def test_convert_invalid_values(self, value: bytes, endian: Endian):
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidInputFormat):
             convert_int8(value, endian)
 
 
@@ -181,7 +182,7 @@ class TestConvertInt16:
         ),
     )
     def test_convert_invalid_values(self, value: bytes, endian: Endian):
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidInputFormat):
             convert_int16(value, endian)
 
 
@@ -216,7 +217,7 @@ class TestConvertInt32:
         ),
     )
     def test_convert_invalid_values(self, value: bytes, endian: Endian):
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidInputFormat):
             convert_int32(value, endian)
 
 
@@ -257,7 +258,7 @@ class TestConvertInt64:
         ),
     )
     def test_convert_invalid_values(self, value: bytes, endian: Endian):
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidInputFormat):
             convert_int64(value, endian)
 
 
@@ -287,7 +288,7 @@ class TestMultibytesInteger:
         ),
     )
     def test_decode_invalid_values(self, value: bytes):
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidInputFormat):
             decode_multibyte_integer(value)
 
 
@@ -426,6 +427,6 @@ class TestGetEndian:
         file = io.BytesIO(bytes.fromhex("FFFF 0000"))
         file.seek(-1, io.SEEK_END)
         pos = file.tell()
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidInputFormat):
             get_endian(file, 0xFFFF_0000)
         assert file.tell() == pos

--- a/unblob/finder.py
+++ b/unblob/finder.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Tuple, Type
 import yara
 from structlog import get_logger
 
-from .file_utils import LimitedStartReader
+from .file_utils import InvalidInputFormat, LimitedStartReader
 from .handlers import ALL_HANDLERS_BY_PRIORITY
 from .logging import noformat
 from .models import Handler, ValidChunk, YaraMatchResult
@@ -72,6 +72,13 @@ def search_chunks_by_priority(  # noqa: C901
                 limited_reader = LimitedStartReader(file, real_offset)
                 try:
                     chunk = handler.calculate_chunk(limited_reader, real_offset)
+                except InvalidInputFormat as exc:
+                    logger.debug(
+                        "File format is invalid",
+                        exc_info=exc,
+                        handler=handler.NAME,
+                    )
+                    continue
                 except EOFError as exc:
                     logger.debug(
                         "File ends before header could be read",

--- a/unblob/handlers/archive/cpio.py
+++ b/unblob/handlers/archive/cpio.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from structlog import get_logger
 
-from ...file_utils import round_up, snull
+from ...file_utils import decode_int, round_up, snull
 from ...models import StructHandler, ValidChunk
 
 logger = get_logger()
@@ -157,11 +157,11 @@ class PortableOldASCIIHandler(_CPIOHandlerBase):
 
     @staticmethod
     def _calculate_file_size(header) -> int:
-        return int(header.c_filesize, 8)
+        return decode_int(header.c_filesize, 8)
 
     @staticmethod
     def _calculate_name_size(header) -> int:
-        return int(header.c_namesize, 8)
+        return decode_int(header.c_namesize, 8)
 
 
 class _NewASCIICommon(StructHandler):
@@ -201,11 +201,11 @@ class PortableASCIIHandler(_NewASCIICommon, _CPIOHandlerBase):
 
     @staticmethod
     def _calculate_file_size(header) -> int:
-        return int(header.c_filesize, 16)
+        return decode_int(header.c_filesize, 16)
 
     @staticmethod
     def _calculate_name_size(header) -> int:
-        return int(header.c_namesize, 16)
+        return decode_int(header.c_namesize, 16)
 
 
 class PortableASCIIWithCRCHandler(_NewASCIICommon, _CPIOHandlerBase):
@@ -220,8 +220,8 @@ class PortableASCIIWithCRCHandler(_NewASCIICommon, _CPIOHandlerBase):
 
     @staticmethod
     def _calculate_file_size(header):
-        return int(header.c_filesize, 16)
+        return decode_int(header.c_filesize, 16)
 
     @staticmethod
     def _calculate_name_size(header):
-        return int(header.c_namesize, 16)
+        return decode_int(header.c_namesize, 16)

--- a/unblob/handlers/archive/tar.py
+++ b/unblob/handlers/archive/tar.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from structlog import get_logger
 
-from ...file_utils import round_down, round_up, snull
+from ...file_utils import decode_int, round_down, round_up, snull
 from ...models import StructHandler, ValidChunk
 
 logger = get_logger()
@@ -104,10 +104,7 @@ class TarHandler(StructHandler):
     ) -> Optional[ValidChunk]:
         header = self.parse_header(file)
         header_size = snull(header.size)
-        try:
-            int(header_size, 8)
-        except ValueError:
-            return
+        decode_int(header_size, 8)
 
         file.seek(start_offset)
         end_offset = _get_tar_end_offset(file)

--- a/unblob/handlers/compression/gzip.py
+++ b/unblob/handlers/compression/gzip.py
@@ -17,7 +17,7 @@ from typing import List, Optional
 
 from structlog import get_logger
 
-from ...file_utils import read_until_past
+from ...file_utils import InvalidInputFormat, read_until_past
 from ...models import Handler, ValidChunk
 from ._gzip_reader import SingleMemberGzipReader
 
@@ -55,8 +55,7 @@ class GZIPHandler(Handler):
         try:
             fp.read_until_eof()
         except gzip.BadGzipFile as e:
-            logger.warn(e)
-            return
+            raise InvalidInputFormat from e
 
         file.seek(GZIP2_FOOTER_LEN - len(fp.unused_data), io.SEEK_CUR)
 

--- a/unblob/handlers/compression/lzip.py
+++ b/unblob/handlers/compression/lzip.py
@@ -38,10 +38,7 @@ class LZipHandler(Handler):
 
         while True:
             file.seek(LZMA_ALIGNMENT, io.SEEK_CUR)
-            try:
-                member_size = convert_int64(file.read(8), Endian.LITTLE)
-            except ValueError:
-                return
+            member_size = convert_int64(file.read(8), Endian.LITTLE)
             if member_size == (file.tell() - start_offset):
                 end_offset = file.tell()
                 break

--- a/unblob/handlers/compression/lzma.py
+++ b/unblob/handlers/compression/lzma.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from structlog import get_logger
 
-from ...file_utils import DEFAULT_BUFSIZE
+from ...file_utils import DEFAULT_BUFSIZE, InvalidInputFormat
 from ...models import Handler, ValidChunk
 
 logger = get_logger()
@@ -31,8 +31,8 @@ class LZMAHandler(Handler):
             while data and not decompressor.eof:
                 decompressor.decompress(data)
                 data = file.read(DEFAULT_BUFSIZE)
-        except lzma.LZMAError:
-            return
+        except lzma.LZMAError as exc:
+            raise InvalidInputFormat from exc
 
         return ValidChunk(
             start_offset=start_offset,

--- a/unblob/handlers/filesystem/extfs.py
+++ b/unblob/handlers/filesystem/extfs.py
@@ -3,6 +3,8 @@ from typing import List, Optional
 
 from structlog import get_logger
 
+from unblob.file_utils import InvalidInputFormat
+
 from ...models import StructHandler, ValidChunk
 
 logger = get_logger()
@@ -99,7 +101,7 @@ class EXTHandler(StructHandler):
         )
 
         if not self.valid_header(header):
-            return
+            raise InvalidInputFormat("Invalid ExtFS header.")
 
         return ValidChunk(
             start_offset=start_offset,

--- a/unblob/handlers/filesystem/jffs2.py
+++ b/unblob/handlers/filesystem/jffs2.py
@@ -3,7 +3,13 @@ from typing import List, Optional
 
 from structlog import get_logger
 
-from unblob.file_utils import Endian, convert_int16, read_until_past, round_up
+from unblob.file_utils import (
+    Endian,
+    InvalidInputFormat,
+    convert_int16,
+    read_until_past,
+    round_up,
+)
 
 from ...models import StructHandler, ValidChunk
 
@@ -106,8 +112,7 @@ class _JFFS2Base(StructHandler):
             current_offset += node_len
 
         if current_offset > eof:
-            # corrupt file or last chunk isn't really jffs2
-            return
+            raise InvalidInputFormat("Corrupt file or last chunk isn't really JFFS2")
 
         return ValidChunk(
             start_offset=start_offset,

--- a/unblob/handlers/filesystem/ntfs.py
+++ b/unblob/handlers/filesystem/ntfs.py
@@ -3,6 +3,8 @@ from typing import List, Optional
 
 from structlog import get_logger
 
+from unblob.file_utils import InvalidInputFormat
+
 from ...models import StructHandler, ValidChunk
 
 logger = get_logger()
@@ -66,7 +68,7 @@ class NTFSHandler(StructHandler):
 
         fsize = header.total_sectors * header.bytes_per_sector
         if fsize == 0:
-            return
+            raise InvalidInputFormat("NTFS header with null disk size.")
 
         end_offset = start_offset + len(header) + fsize
         return ValidChunk(

--- a/unblob/handlers/filesystem/ubi.py
+++ b/unblob/handlers/filesystem/ubi.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from structlog import get_logger
 
-from ...file_utils import get_endian, iterate_patterns
+from ...file_utils import InvalidInputFormat, get_endian, iterate_patterns
 from ...iter_utils import get_intervals
 from ...models import Handler, StructHandler, ValidChunk
 
@@ -125,7 +125,7 @@ class UBIHandler(Handler):
 
         offset_intervals = get_intervals(all_ubi_eraseblock_offsets)
         if not offset_intervals:
-            raise PEBSizeNotFound
+            raise InvalidInputFormat
 
         return statistics.mode(offset_intervals)
 
@@ -143,10 +143,8 @@ class UBIHandler(Handler):
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int
     ) -> Optional[ValidChunk]:
-        try:
-            peb_size = self._guess_peb_size(file)
-        except PEBSizeNotFound:
-            return
+
+        peb_size = self._guess_peb_size(file)
 
         logger.debug("Guessed UBI PEB size", size=peb_size)
 


### PR DESCRIPTION
Multiple issues were identified during fuzzing (#177, #178), mostly related to `ValueError` exceptions being triggered during integer base conversions or struct unpacking.

We harden unblob against these by inserting an `InvalidInputFormat` exception that is globally captured. This exception can be raised by handlers so they don't need to verify return values or capture exceptions locally anymore. The exception along with the whole stacktrace will be logged by unblob if running in debug mode.

Test files and handlers were modified accordingly.