### PR TITLE
UnixCompress: Speed-up Yara rule

### DIFF
--- a/unblob/handlers/compression/compress.py
+++ b/unblob/handlers/compression/compress.py
@@ -47,7 +47,7 @@ class UnixCompressHandler(StructHandler):
     YARA_RULE = r"""
         strings:
             // magic
-            $compress_magic = /[\x1f][\x9d][\x00-\xff]/
+            $compress_magic = { 1f 9d }
         condition:
             $compress_magic
     """


### PR DESCRIPTION
Regular expressions are much slower than literal patterns. This
transformation causes a 6x performance increase of the given stage.