### PR TITLE
Remove yara scanning timeout.

### DIFF
--- a/unblob/finder.py
+++ b/unblob/finder.py
@@ -138,7 +138,7 @@ def search_yara_patterns(
 ) -> List[YaraMatchResult]:
     """Search with the compiled YARA rules and identify the handler which defined the rule."""
     # YARA uses a memory mapped file internally when given a path
-    yara_matches: List[yara.Match] = yara_rules.match(full_path.as_posix(), timeout=60)
+    yara_matches: List[yara.Match] = yara_rules.match(full_path.as_posix())
 
     yara_results = []
     for match in yara_matches:


### PR DESCRIPTION
Let's get rid of yara timeout given that only 0.00375% of our corpus hit the 60 seconds limit due to their size and that Yara scanning scales linearly.

End users can rely on coreutils's `timeout` command to limit unblob execution time if they want :)