### PR TITLE
Fix JFFS2 EOFError handling.

### DIFF
--- a/unblob/handlers/filesystem/jffs2.py
+++ b/unblob/handlers/filesystem/jffs2.py
@@ -62,7 +62,9 @@ class _JFFS2Base(StructHandler):
 
     def valid_header(self, header: Instance, node_start_offset: int, eof: int) -> bool:
         if header.nodetype not in JFFS2_NODETYPES:
-            logger.debug("Invalid JFFS2 node type", node_type=header.nodetype)
+            logger.debug(
+                "Invalid JFFS2 node type", node_type=header.nodetype, _verbosity=2
+            )
             return False
 
         if node_start_offset + header.totlen > eof:
@@ -70,11 +72,16 @@ class _JFFS2Base(StructHandler):
                 "node length greater than total file size",
                 node_len=header.totlen,
                 file_size=eof,
+                _verbosity=2,
             )
             return False
 
         if header.totlen < len(header):
-            logger.debug("node length greater than header size", node_len=header.totlen)
+            logger.debug(
+                "node length greater than header size",
+                node_len=header.totlen,
+                _verbosity=2,
+            )
             return False
         return True
 
@@ -105,7 +112,11 @@ class _JFFS2Base(StructHandler):
                     current_offset = read_until_past(file, b"\x00\xFF")
                     continue
                 else:
-                    logger.debug("unexpected header magic", header_magic=header.magic)
+                    logger.debug(
+                        "unexpected header magic",
+                        header_magic=header.magic,
+                        _verbosity=2,
+                    )
                     break
 
             if not self.valid_header(header, node_start_offset, eof):


### PR DESCRIPTION
When a JFFS2 filesystem is located at the very end of a file being analyzed by unblob, the JFFS2 filesystem ended up not being properly identified due to an uncaught EOFError exception being raised when parsing a JFFS2 node header.

We fixed this by capturing this error early and breaking out of the loop when that happens.

We also moved the node header validation to a dedicated function so that cyclomatic complexity of calculate_chunk would stay low.