### PR TITLE
pool: remove `join` call on close

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,17 +12,17 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-        name: Check flake8
-
   - repo: https://github.com/psf/black
     rev: 21.12b0
     hooks:
       - id: black
         name: Check black
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        name: Check flake8
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -57,3 +57,23 @@ def test_multipool(process_num: int):
 
     assert list(handled) == [5, 4, 3, 2, 1, 0]
     assert list(results) == [5, 4, 3, 2, 1, 0]
+
+
+def test_input_cannot_be_submitted_from_worker():
+    pool: MultiPool
+
+    def submit_task(_):
+        nonlocal pool
+        try:
+            pool.submit("this should fail")
+        except Exception as exc:
+            return exc
+
+    def raise_result(_pool, result):
+        raise result
+
+    pool = MultiPool(process_num=1, handler=submit_task, result_callback=raise_result)
+
+    with pool, pytest.raises(RuntimeError, match="can only be called"):
+        pool.submit(1)
+        pool.process_until_done()

--- a/unblob/pool.py
+++ b/unblob/pool.py
@@ -73,7 +73,6 @@ class MultiPool(PoolBase):
             p.start()
 
     def close(self):
-        self._input.join()
         for p in self._procs:
             p.terminate()
             p.join()


### PR DESCRIPTION
The join in `close` is unsound: We either call `process_until_done` and let
it do its job, then the `is_empty` condition returning False is
equivalent to a `join` that would not block or we either didn't call
`process_until_done` or it failed with an exception, in which case the
queue never gets emptied and this line will block forever.

Instead of terminate, we place a sentinel object to the input queue so
that all processes have a chance to wake up and exit. In order to not
wait for arbitrary amount of time for the workers, we empty the input
queue from the main thread. In order to guarantee that this operation
is sound, we disallow placing subsequent tasks from other threads and
processes.

This change also means that the currently running task will always
finish.