### PR TITLE
Fixed squashfs padding (#237)

### DIFF
--- a/unblob/handlers/filesystem/squashfs.py
+++ b/unblob/handlers/filesystem/squashfs.py
@@ -8,7 +8,7 @@ from ...models import StructHandler, ValidChunk
 
 logger = get_logger()
 
-PAD_SIZE = 4_096
+PAD_SIZE = 1_024
 BIG_ENDIAN_MAGIC = 0x73_71_73_68
 
 


### PR DESCRIPTION
Squashfs files can be 1k padded not just 4k padded.
There is no standard how squashfs should be padded, in the kernel it
depends on actually the kernel settings:
https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/fs/squashfs/Kconfig#L183
https://github.com/torvalds/linux/commit/7657cacf478940b995c2c73fdff981c13cc62c5ctorvalds/linux@7657cac

Userspace tools usually use 4k padding as that is compatible with both
1k and 4k padding, but there could be 1k padded squashfs files out there:
https://dr-emann.github.io/squashfs/squashfs.html

For our end calculation using 4k could easily result in an overflow.
Unfortunately there is no easy way to detect this as the bytes_used is no
indication in this matter. We might be able to see if 4k would overflow
the file and just failback to 1k in those cases or set it to 1k always.

As originally files were 1k padded it might be OK to always use 1k as
padding, bottom line we would miss a 3k block at the end as an unknown
chunk which is probably 0 padded anyhow.

Interestingly it is even possible to create filesystem that is not
padded at all (however current mksquashfs can only do 4k padding, though
other tools might be different)
https://github.com/plougher/squashfs-tools/blob/23996602b0f7db407914aa9479fc41cb12b4c732/USAGE#L245
https://github.com/plougher/squashfs-tools/blob/62b7f5a411767409d2ec782a92ed632099b422d5/ACKNOWLEDGEMENTS#L101