### PR TITLE
Yara rules optimization

### DIFF
--- a/unblob/handlers/compression/gzip.py
+++ b/unblob/handlers/compression/gzip.py
@@ -38,9 +38,9 @@ class GZIPHandler(Handler):
         // compression method (0x8 = DEFLATE)
         // flags, 00011111 (0x1f) is the highest since the first 3 bits are reserved
         // unix time
-        // eXtra FLags
-        // Operating System (RFC1952 describes 0-13, or 255)
-        $gzip_magic = /\x1f\x8b\x08[\x00-\x1f][\x00-\xff]{4}[\x00-\x04][\x00-\x0c\xff]/
+        // eXtra FLags (2 or 4 per RFC1952 2.3.1)
+        // Operating System (0-13, or 255 per RFC1952 2.3.1)
+        $gzip_magic = { 1F 8B 08 (00 | 01 | 02 | 03 | 04 | 05 | 06 | 07 | 08 | 09 | 0A | 0B | 0C | 0D | 0E | 0F | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 1A | 1B | 1C | 1D | 1E) [4] (02 | 04) (00 | 01 | 02 | 03 | 04 | 05 | 06 | 07 | 08 | 09 | 0A | 0B | 0C | 0D | FF) }
     condition:
         $gzip_magic
     """


### PR DESCRIPTION
Improved yara rules for the following handlers:

- unix compress
- LZMA
- CPIO binary
- GZIP
- LZH

These rules were either fixed (GZIP operating system field acceptable values), enhanced for speed improvements (LZH), or improved by offloading some fields validation to the yara engine in order to limit the amount of false positives.

The following checks were offloaded to yara:

- GZIP (validate modification time)
- CPIO (valide c_mode field)
- LZMA (validate dictionary size and uncompressed length fields)
- unix compress (validate the first LZW code)
