### PR TITLE
Fix ZIP handler end offset calculation.

### DIFF
--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -105,20 +105,6 @@ def decode_multibyte_integer(data: bytes) -> Tuple[int, int]:
     raise InvalidInputFormat("Multibyte integer decoding failed.")
 
 
-def find_first(
-    file: io.BufferedIOBase, pattern: bytes, chunk_size: int = 0x1000
-) -> int:
-    """Search for the pattern and return the absolute position of the start of the pattern in the file.
-    Returns -1 if not found.
-    Seek the file pointer to the next byte of where we found the pattern or
-    seek back to the initial position when we did not find it.
-    """
-    try:
-        return next(iterate_patterns(file, pattern, chunk_size))
-    except StopIteration:
-        return -1
-
-
 def iterate_patterns(
     file: io.BufferedIOBase, pattern: bytes, chunk_size: int = 0x1000
 ) -> Iterator[int]:

--- a/unblob/handlers/archive/zip.py
+++ b/unblob/handlers/archive/zip.py
@@ -1,18 +1,17 @@
 import io
-import zipfile
-from typing import List, Optional, Tuple
+import struct
+from typing import List, Optional
 
+from dissect.cstruct import Instance
 from structlog import get_logger
 
-from ...file_utils import InvalidInputFormat, find_first
+from ...file_utils import InvalidInputFormat, iterate_patterns
 from ...models import StructHandler, ValidChunk
 
 logger = get_logger()
 
-
-MAXIMUM_VERSION = 0xFF
-EOCD_RECORD_HEADER = b"\x50\x4b\x05\x06"
 ENCRYPTED_FLAG = 0b0001
+EOCD_RECORD_HEADER = 0x6054B50
 
 
 class ZIPHandler(StructHandler):
@@ -26,22 +25,28 @@ class ZIPHandler(StructHandler):
     """
 
     C_DEFINITIONS = r"""
-        typedef struct local_file_header
-        {
-            uint32 local_file_header_signature;
-            uint16 version_needed_to_extract;
-            uint16 gp_bitflag;
+
+        typedef struct cd_file_header {
+            uint32 magic;
+            uint16 version_made_by;
+            uint16 version_needed;
+            uint16 flags;
             uint16 compression_method;
-            uint16 last_mod_file_time;
-            uint16 last_mod_file_date;
-            uint32 crc32;
-            uint32 compressed_size;
-            uint32 uncompressed_size;
+            uint16 dostime;
+            uint16 dosdate;
+            uint32 crc32_cs;
+            uint32 compress_size;
+            uint32 file_size;
             uint16 file_name_length;
             uint16 extra_field_length;
+            uint16 file_comment_length;
+            uint16 disk_number_start;
+            uint16 internal_file_attr;
+            uint32 external_file_attr;
+            uint32 relative_offset_local_header;
             char file_name[file_name_length];
             char extra_field[extra_field_length];
-        } local_file_header_t;
+        } cd_file_header_t;
 
         typedef struct end_of_central_directory
         {
@@ -56,60 +61,54 @@ class ZIPHandler(StructHandler):
             char zip_file_comment[comment_len];
         } end_of_central_directory_t;
     """
-    HEADER_STRUCT = "local_file_header_t"
+    HEADER_STRUCT = "end_of_central_directory_t"
 
-    def _calculate_zipfile_end(self, file: io.BufferedIOBase, start_offset: int) -> int:
-        # If we just pass a file with multiple ZIP files in it to zipfile.ZipFile, it seems
-        # that it will basically scan for the final EOCD record header, and assume
-        # that's where the file ends.
-        # E.g. in the case our file looks like this:
-        # | ZIPFILE | SOMETHING ELSE | ZIPFILE |
-        # zipfile.ZipFile() will assume:
-        # |    THIS IS ALL THE SAME ZIPFILE    |
-        # For obvious reasons, this is not helpful in our case. We need to try to guess the length of
-        # the ZIP file chunk within our file independently, and then carve that chunk out.
-
-        file.seek(start_offset)
-
-        zip_end = find_first(file, EOCD_RECORD_HEADER)
-
-        if zip_end == -1:
-            raise InvalidInputFormat("Missing EOCD record header in ZIP chunk.")
-
-        file.seek(zip_end)
-        self.cparser_le.end_of_central_directory_t(file)
-        return file.tell()
-
-    def check_file(self, file: io.BufferedIOBase) -> Tuple[bool, bool]:
-        has_encrypted_files = False
-        try:
-            with zipfile.ZipFile(file) as zip:  # type: ignore
-                for zipinfo in zip.infolist():
-                    if zipinfo.flag_bits & ENCRYPTED_FLAG:
-                        has_encrypted_files = True
-            return True, has_encrypted_files
-        except (zipfile.BadZipFile, UnicodeDecodeError, ValueError):
-            return False, has_encrypted_files
+    def has_encrypted_files(
+        self,
+        file: io.BufferedIOBase,
+        start_offset: int,
+        end_of_central_directory: Instance,
+    ) -> bool:
+        file.seek(start_offset + end_of_central_directory.offset_of_cd, io.SEEK_SET)
+        for _ in range(0, end_of_central_directory.total_entries):
+            cd_header = self.cparser_le.cd_file_header_t(file)
+            if cd_header.flags & ENCRYPTED_FLAG:
+                return True
+        return False
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int
     ) -> Optional[ValidChunk]:
 
-        header = self.parse_header(file)
-        if header.version_needed_to_extract > MAXIMUM_VERSION:
-            return
+        has_encrypted_files = False
+        file.seek(start_offset, io.SEEK_SET)
 
-        end_of_zip = self._calculate_zipfile_end(file, start_offset)
-        file.seek(start_offset)
+        for offset in iterate_patterns(file, struct.pack("<I", EOCD_RECORD_HEADER)):
+            file.seek(offset, io.SEEK_SET)
+            end_of_central_directory = self.parse_header(file)
 
-        is_valid, has_encrypted_files = self.check_file(file)
+            # the EOCD offset is equal to the offset of CD + size of CD
+            end_of_central_directory_offset = (
+                start_offset
+                + end_of_central_directory.offset_of_cd
+                + end_of_central_directory.central_directory_size
+            )
 
-        if not is_valid:
-            raise InvalidInputFormat("Invalid ZIP header.")
+            if offset == end_of_central_directory_offset:
+                break
+        else:
+            raise InvalidInputFormat("Missing EOCD record header in ZIP chunk.")
+
+        has_encrypted_files = self.has_encrypted_files(
+            file, start_offset, end_of_central_directory
+        )
+
+        file.seek(offset, io.SEEK_SET)
+        self.cparser_le.end_of_central_directory_t(file)
 
         return ValidChunk(
             start_offset=start_offset,
-            end_offset=end_of_zip,
+            end_offset=file.tell(),
             is_encrypted=has_encrypted_files,
         )
 


### PR DESCRIPTION
This is a complete rewrite of the ZIP handler due to multiple issues that have been identified during testing.

**Python's built-in zipfile library is not reliable for our use.**

This is due to the fact that zipfile seeks to the very end of the file and then search backwards for the first occurence of central directory.

This is problematic because if we have a file fed to unblob that is made of two concatenated ZIP files (with or without arbitrary content in between), the end offset identified by zipfile would be the one of the second zip chunk within the overall file, which is wrong in our case.

**Simply finding the end of central directory marker is not enough**

We previously searched for the EOCD marker and consider our first match as the EOCD offset of the ZIP chunk we're currently investigating.

This is not sufficient because ZIP compression may not fully scramble the data of the files it contains. This means that if you have a ZIP within a ZIP, our first EOCD marker match will be the one of the ZIP within the ZIP chunk we're currently trying to find the end offset of.

To overcome this, we iterate over all EOCD marker offsets within the file and check for each of them whether or not their `offset_of_cd` value points to a valid magic for a central directory record header. If there is no match, that means our EOCD marker is not the right one.

This commit also get rid of the 'find_first' function as it turned into dead code and vulture won't let me commit if I leave it there.