### PR TITLE
Replace extfs filesystem handler extractor.

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -7,7 +7,7 @@ runs:
   using: "composite"
   steps:
     - name: Install 3rd party from apt
-      run: sudo apt install unar zlib1g-dev liblzo2-dev lzop lziprecover img2simg
+      run: sudo apt install e2fsprogs unar zlib1g-dev liblzo2-dev lzop lziprecover img2simg
       shell: bash
 
     - name: Install 7zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /data/output
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     curl \
+    e2fsprogs \
     gcc \
     git \
     img2simg \

--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,7 @@
 , rustPlatform
 , yara
 , _7zz
+, e2fsprogs
 , lz4
 , lziprecover
 , lzo
@@ -18,6 +19,7 @@ let
   # These dependencies are only added to PATH
   runtimeDeps = [
     _7z
+    e2fsprogs
     lz4
     lziprecover
     lzop

--- a/unblob/handlers/filesystem/extfs.py
+++ b/unblob/handlers/filesystem/extfs.py
@@ -110,4 +110,4 @@ class EXTHandler(StructHandler):
 
     @staticmethod
     def make_extract_command(inpath: str, outdir: str) -> List[str]:
-        return ["7z", "x", "-y", inpath, f"-o{outdir}"]
+        return ["debugfs", inpath, "-R", f"rdump / {outdir}"]


### PR DESCRIPTION
We replaced 7z by debugfs given that 7z cannot extract all the extfs samples we have in our corpus.

Fix #277 