### PR TITLE
Revert to 7zip v16.02 from 7zip v21.07.

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -7,15 +7,7 @@ runs:
   using: "composite"
   steps:
     - name: Install 3rd party from apt
-      run: sudo apt install e2fsprogs unar zlib1g-dev liblzo2-dev lzop lziprecover img2simg
-      shell: bash
-
-    - name: Install 7zip
-      run: |
-        sudo apt remove -y p7zip
-        curl -s https://www.7-zip.org/a/7z2107-linux-x64.tar.xz --output - | tar Jxvf - 7zzs
-        sudo mv 7zzs /usr/local/bin/7z
-        sudo chmod +x /usr/local/bin/7z
+      run: sudo apt install e2fsprogs p7zip-full unar zlib1g-dev liblzo2-dev lzop lziprecover img2simg
       shell: bash
 
     - name: Install sasquatch

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     lz4 \
     lziprecover \
     lzop \
+    p7zip-full \
     unar \
     xz-utils \
     zlib1g-dev
-RUN curl -s https://www.7-zip.org/a/7z2107-linux-x64.tar.xz --output - \
-    | tar -C /usr/local/bin --transform 's/7zzs/7z/' -Jxvf - 7zzs
 RUN curl -L -o sasquatch_1.0_amd64.deb https://github.com/IoT-Inspector/sasquatch/releases/download/sasquatch-v1.0/sasquatch_1.0_amd64.deb \
     && dpkg -i sasquatch_1.0_amd64.deb \
     && rm -f sasquatch_1.0_amd64.deb

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ These are the **external** extractor version recommendations. These are used in 
 
 | Extractor                                 |   Version   |
 |-------------------------------------------| ----------- |
-| 7z                                        | 21.07       |
+| 7z (p7zip-full)                           | 16.02       |
 | lz4                                       | 1.9.3       |
 | lziprecover                               | 1.22        |
 | lzop                                      | 1.04        |

--- a/default.nix
+++ b/default.nix
@@ -1,37 +1,31 @@
 { lib
-, runCommand
 , poetry2nix
 , python3
 , rustPlatform
 , yara
-, _7zz
 , e2fsprogs
 , lz4
 , lziprecover
 , lzo
 , lzop
-, simg2img
+, p7zip
 , sasquatch
+, simg2img
 , unar
 }:
 
 let
   # These dependencies are only added to PATH
   runtimeDeps = [
-    _7z
     e2fsprogs
     lz4
     lziprecover
     lzop
-    simg2img
+    p7zip
     sasquatch
+    simg2img
     unar
   ];
-
-  _7z = runCommand "7z" { } ''
-    mkdir -p $out/bin
-    ln -snf ${_7zz}/bin/7zz $out/bin/7z
-  '';
 
   self = poetry2nix.mkPoetryApplication {
     projectDir = ./.;


### PR DESCRIPTION
We were relying on 7zip version 21.07 from the official repo due to the lack of support for ext4 filesystems in 7zip version 16.02 provided by the p7zip-full package.

We replaced the extfs extractor by debugfs since 7f77c7d, which means we can revert back to using p7zip-full to simplify our build tasks and make life easier on end users who would like to test without performing manual 'copy/install'.

Fix #258 