### PR TITLE
Check lockfile

### DIFF
--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -1,0 +1,24 @@
+name: Poetry
+
+on:
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+      - 'poetry.lock'
+
+jobs:
+  check_poetry:
+    name: Check poetry.lock consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Setup Poetry
+        run: python -m pip install --upgrade poetry
+
+      - name: Check poetry.lock
+        run: |
+          poetry lock --no-update
+          git diff --exit-code -- poetry.lock
+        shell: bash


### PR DESCRIPTION
There will be a `poetry lock --check` command whenever Poetry 1.2.0 is released. Until then, we can still check if locking produces an idempotent result.

Workflow is only ran when `pyproject.toml` or `poetry.lock` changes so it won't cause any overhead for most PRs