### PR TITLE
Nix shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,5 @@
 { lib
+, makeWrapper
 , poetry2nix
 , python3
 , rustPlatform
@@ -69,6 +70,7 @@ let
 
     nativeBuildInputs = with rustPlatform; [
       cargoSetupHook
+      makeWrapper
       rust.cargo
       rust.rustc
     ];

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 { lib
 , makeWrapper
+, mkPoetryApp
 , poetry2nix
 , python3
 , rustPlatform
@@ -29,7 +30,7 @@ let
     unar
   ];
 
-  self = poetry2nix.mkPoetryApplication {
+  self = mkPoetryApp {
     projectDir = ./.;
 
     # Python dependencies that need special care, like non-python
@@ -74,10 +75,13 @@ let
       rust.cargo
       rust.rustc
     ];
+
+    editablePackageSources = { "unblob" = ./unblob; };
   };
 in
 self // {
-  withTests = self.overridePythonAttrs (_: {
+  inherit runtimeDeps;
+  withTests = self.app.overridePythonAttrs (_: {
     checkPhase = ''
       (
         deps_PATH=${lib.makeBinPath runtimeDeps}

--- a/flake.nix
+++ b/flake.nix
@@ -28,5 +28,9 @@
       };
 
       defaultPackage.${system} = unblob;
+
+      devShell.${system} = pkgs.mkShell {
+        packages = [ unblob.editableEnv unblob.runtimeDeps ];
+      };
     };
 }

--- a/nix/poetry/default.nix
+++ b/nix/poetry/default.nix
@@ -1,0 +1,43 @@
+# Here we define both the final application and an editable virtualenv
+# for use during development, as they share common
+# dependencies. Unfortunately `poetr2nix` defines quite different
+# semantics for the two.
+
+
+{ lib, mkShell, poetry2nix, stdenv, rustPlatform }:
+
+{ projectDir, overrides, editablePackageSources, ... }@args:
+
+let
+  # pass all args which are not specific to mkPoetryEnv
+  app = poetry2nix.mkPoetryApplication (builtins.removeAttrs args [ "editablePackageSources" ]);
+
+  # pass args specific to mkPoetryEnv and all remaining arguments to mkDerivation
+  editableEnv =
+    stdenv.mkDerivation (
+      {
+        name = "${app.pname}-editable-env";
+        src = poetry2nix.mkPoetryEnv {
+          inherit projectDir editablePackageSources overrides;
+        };
+
+        installPhase = ''
+          mkdir -p $out
+          cp -a * $out
+        '';
+
+        # cargoSetupHook won't work for building the python environment
+        nativeBuildInputs = builtins.filter
+          (inp: inp != rustPlatform.cargoSetupHook)
+          args.nativeBuildInputs;
+      } // builtins.removeAttrs args [
+        "editablePackageSources"
+        "nativeBuildInputs"
+        "overrides"
+        "projectDir"
+      ]
+    );
+in
+app.overrideAttrs (super: {
+  passthru = super.passthru // { inherit app editableEnv; };
+})

--- a/overlay.nix
+++ b/overlay.nix
@@ -5,4 +5,5 @@ inputs: final: prev:
   gnustep = prev.callPackage ./nix/gnustep { inherit (prev) gnustep; };
   yara = prev.callPackage ./nix/yara { inherit (prev) yara; };
   sasquatch = prev.callPackage ./nix/sasquatch { inherit (prev) squashfsTools; src = inputs.sasquatch; };
+  mkPoetryApp = prev.callPackage ./nix/poetry { };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,6 @@
+# This file is to let "legacy" nix-shell command work in addition to `nix develop`
+let
+  flake = builtins.getFlake (toString ./.);
+  system = builtins.currentSystem;
+in
+flake.devShell."${system}"


### PR DESCRIPTION
Issuing `nix develop` will create a temporary environment with editable version of unblob and all other dependencies installed