### PR TITLE
Cleanup carved files

### DIFF
--- a/tests/extractors/test_command.py
+++ b/tests/extractors/test_command.py
@@ -5,7 +5,7 @@ import pytest
 
 from unblob.extractors import Command
 from unblob.extractors.command import InvalidCommandTemplate
-from unblob.models import ExtractError, TaskResult
+from unblob.models import ExtractError
 from unblob.report import ExtractCommandFailedReport, ExtractorDependencyNotFoundReport
 
 
@@ -35,40 +35,42 @@ def test_command_templating_with_invalid_substitution(template):
 def test_command_execution(tmpdir: Path):
     outdir = PosixPath(tmpdir)
     command = Command("sh", "-c", "> {outdir}/created")
-    res = TaskResult()
-    command.extract(Path("foo"), outdir, res)
-    assert (outdir / Path("created")).is_file()
 
-    assert res.reports == []
+    command.extract(Path("foo"), outdir)
+
+    assert (outdir / Path("created")).is_file()
 
 
 def test_command_execution_failure(tmpdir: Path):
     outdir = PosixPath(tmpdir)
     command = Command("sh", "-c", ">&1 echo -n stdout; >&2 echo -n stderr; false")
 
-    res = TaskResult()
-    with pytest.raises(ExtractError):
-        command.extract(Path("input"), outdir, res)
-    assert res.reports == [
-        ExtractCommandFailedReport(
-            handler=None,
-            command=mock.ANY,
-            stdout=b"stdout",
-            stderr=b"stderr",
-            exit_code=1,
-        )
-    ]
+    try:
+        command.extract(Path("input"), outdir)
+        pytest.fail("ExtractError not raised")
+    except ExtractError as e:
+        assert list(e.reports) == [
+            ExtractCommandFailedReport(
+                handler=None,
+                command=mock.ANY,
+                stdout=b"stdout",
+                stderr=b"stderr",
+                exit_code=1,
+            )
+        ]
 
 
 def test_command_not_found(tmpdir: Path):
     outdir = PosixPath(tmpdir)
     command = Command("this-command-should-not-exist-in-any-system")
 
-    res = TaskResult()
-    with pytest.raises(ExtractError):
-        command.extract(Path("input"), outdir, res)
-    assert res.reports == [
-        ExtractorDependencyNotFoundReport(
-            handler=None, dependencies=["this-command-should-not-exist-in-any-system"]
-        )
-    ]
+    try:
+        command.extract(Path("input"), outdir)
+        pytest.fail("ExtractError not raised")
+    except ExtractError as e:
+        assert list(e.reports) == [
+            ExtractorDependencyNotFoundReport(
+                handler=None,
+                dependencies=["this-command-should-not-exist-in-any-system"],
+            )
+        ]

--- a/tests/extractors/test_command.py
+++ b/tests/extractors/test_command.py
@@ -5,7 +5,7 @@ import pytest
 
 from unblob.extractors import Command
 from unblob.extractors.command import InvalidCommandTemplate
-from unblob.models import TaskResult
+from unblob.models import ExtractError, TaskResult
 from unblob.report import ExtractCommandFailedReport, ExtractorDependencyNotFoundReport
 
 
@@ -47,7 +47,8 @@ def test_command_execution_failure(tmpdir: Path):
     command = Command("sh", "-c", ">&1 echo -n stdout; >&2 echo -n stderr; false")
 
     res = TaskResult()
-    command.extract(Path("input"), outdir, res)
+    with pytest.raises(ExtractError):
+        command.extract(Path("input"), outdir, res)
     assert res.reports == [
         ExtractCommandFailedReport(
             handler=None,
@@ -64,7 +65,8 @@ def test_command_not_found(tmpdir: Path):
     command = Command("this-command-should-not-exist-in-any-system")
 
     res = TaskResult()
-    command.extract(Path("input"), outdir, res)
+    with pytest.raises(ExtractError):
+        command.extract(Path("input"), outdir, res)
     assert res.reports == [
         ExtractorDependencyNotFoundReport(
             handler=None, dependencies=["this-command-should-not-exist-in-any-system"]

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,115 @@
+"""Tests for [not] cleaning up extracted files.
+
+The tests use zip files as inputs - for simplicity
+"""
+import io
+import os
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from unblob.models import Handler, Handlers, ValidChunk
+from unblob.processing import process_file
+
+_ZIP_CONTENT = b"good file"
+# replacing _ZIP_CONTENT with _DAMAGED_ZIP_CONTENT will result in CRC error at unpacking time
+_DAMAGED_ZIP_CONTENT = b"*BAD*file"
+
+
+def _zip_bytes() -> bytes:
+    bio = io.BytesIO()
+    z = zipfile.ZipFile(bio, mode="w", compression=zipfile.ZIP_STORED)
+    z.writestr("content.txt", _ZIP_CONTENT)
+    z.close()
+    return bio.getvalue()
+
+
+ZIP_BYTES = _zip_bytes()
+DAMAGED_ZIP_BYTES = ZIP_BYTES.replace(_ZIP_CONTENT, _DAMAGED_ZIP_CONTENT)
+
+
+@pytest.fixture()
+def input_dir(tmp_path: Path):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    return input_dir
+
+
+@pytest.fixture()
+def output_dir(tmp_path):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    return output_dir
+
+
+def test_remove_extracted_chunks(input_dir: Path, output_dir: Path):
+    (input_dir / "blob").write_bytes(ZIP_BYTES)
+    all_reports = process_file(
+        path=input_dir,
+        extract_root=output_dir,
+        entropy_depth=0,
+        keep_extracted_chunks=False,
+    )
+
+    assert list(output_dir.glob("**/*.zip")) == []
+    assert all_reports == [], f"Unexpected error reports: {all_reports}"
+
+
+def test_keep_all_problematic_chunks(input_dir: Path, output_dir: Path):
+    (input_dir / "blob").write_bytes(DAMAGED_ZIP_BYTES)
+    all_reports = process_file(
+        path=input_dir,
+        extract_root=output_dir,
+        entropy_depth=0,
+        keep_extracted_chunks=False,
+    )
+
+    # damaged zip file should not be removed
+    assert all_reports != [], "Unexpectedly no errors found!"
+    assert list(output_dir.glob("**/*.zip"))
+
+
+def test_keep_all_unknown_chunks(input_dir: Path, output_dir: Path):
+    (input_dir / "blob").write_bytes(b"unknown1" + ZIP_BYTES + b"unknown2")
+    all_reports = process_file(
+        path=input_dir,
+        extract_root=output_dir,
+        entropy_depth=0,
+        keep_extracted_chunks=False,
+    )
+
+    assert list(output_dir.glob("**/*.unknown"))
+    assert all_reports == [], f"Unexpected error reports: {all_reports}"
+
+
+class _HandlerWithNullExtractor(Handler):
+    NAME = "null"
+    EXTRACTOR = None
+    YARA_RULE = r"""
+        strings:
+            $anychar = /./
+
+        condition:
+            $anychar
+    """
+
+    def calculate_chunk(self, file: io.BufferedIOBase, start_offset: int) -> ValidChunk:
+        pos = file.tell()
+        length = file.seek(0, os.SEEK_END)
+        file.seek(pos, os.SEEK_SET)
+        return ValidChunk(start_offset=0, end_offset=length)
+
+
+def test_keep_chunks_with_null_extractor(input_dir: Path, output_dir: Path):
+    (input_dir / "blob").write_text("some text")
+    all_reports = process_file(
+        path=input_dir,
+        extract_root=output_dir,
+        entropy_depth=0,
+        keep_extracted_chunks=False,
+        handlers=Handlers([tuple([_HandlerWithNullExtractor])]),
+    )
+
+    assert list(output_dir.glob("**/*.null"))
+    assert all_reports == [], f"Unexpected error reports: {all_reports}"

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -34,6 +34,7 @@ def test_all_handlers(input_dir: Path, output_dir: Path, tmp_path: Path):
         path=input_dir,
         extract_root=tmp_path,
         entropy_depth=0,
+        keep_extracted_chunks=True,
     )
 
     check_output_is_the_same(output_dir, tmp_path)

--- a/unblob/cli.py
+++ b/unblob/cli.py
@@ -120,6 +120,14 @@ class UnblobContext(click.Context):
     help="Number of worker processes to process files parallelly.",
     show_default=True,
 )
+@click.option(
+    "-k",
+    "--keep-extracted-chunks",
+    "keep_extracted_chunks",
+    is_flag=True,
+    show_default=True,
+    help="Keep extracted chunks",
+)
 @verbosity_option
 @click.option(
     "--show-external-dependencies",
@@ -134,6 +142,7 @@ def cli(
     depth: int,
     entropy_depth: int,
     process_num: int,
+    keep_extracted_chunks: bool,
     verbose: int,
     plugins_path: Optional[Path],
     handlers: Handlers,
@@ -156,6 +165,7 @@ def cli(
             entropy_plot=bool(verbose >= 3),
             process_num=process_num,
             handlers=handlers,
+            keep_extracted_chunks=keep_extracted_chunks,
         )
         all_reports.extend(report)
     return all_reports

--- a/unblob/extractors/command.py
+++ b/unblob/extractors/command.py
@@ -5,7 +5,7 @@ from typing import List
 
 from structlog import get_logger
 
-from unblob.models import Extractor, TaskResult
+from unblob.models import ExtractError, Extractor, TaskResult
 from unblob.report import ExtractCommandFailedReport, ExtractorDependencyNotFoundReport
 
 logger = get_logger()
@@ -41,6 +41,7 @@ class Command(Extractor):
 
                 task_result.add_report(error_report)
                 logger.error("Extract command failed", **error_report.asdict())
+                raise ExtractError
         except FileNotFoundError:
             error_report = ExtractorDependencyNotFoundReport(
                 dependencies=self.get_dependencies()
@@ -50,6 +51,7 @@ class Command(Extractor):
                 "Can't run extract command. Is the extractor installed?",
                 **error_report.asdict(),
             )
+            raise ExtractError
 
     def _make_extract_command(self, inpath: Path, outdir: Path):
         replacements = dict(inpath=inpath, outdir=outdir, infile=inpath.stem)

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -204,14 +204,14 @@ class _FileTask:
         inpath, outdir = get_extract_paths(extract_dir, carved_path)
 
         try:
-            chunk.extract(inpath, outdir, self.result)
+            chunk.extract(inpath, outdir)
             if not self.parameters.keep_extracted_chunks:
                 logger.debug("Removing extracted chunk", path=inpath)
                 inpath.unlink()
 
-        except ExtractError:
-            # already reported & logged by extractor
-            pass
+        except ExtractError as e:
+            for report in e.reports:
+                self.result.add_report(report)
 
         except Exception as exc:
             logger.exception("Unknown error happened while extracting chunk")

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -5,6 +5,7 @@ from operator import attrgetter
 from pathlib import Path
 from typing import List
 
+import attr
 import plotext as plt
 from structlog import get_logger
 
@@ -22,7 +23,7 @@ from .finder import search_chunks_by_priority
 from .iter_utils import pairwise
 from .logging import noformat
 from .math import shannon_entropy
-from .models import Extractor, Task, TaskResult, UnknownChunk, ValidChunk
+from .models import ExtractError, Task, TaskResult, UnknownChunk, ValidChunk
 from .pool import make_pool
 from .report import Report, UnknownError
 from .signals import terminate_gracefully
@@ -52,9 +53,14 @@ def process_file(
         depth=0,
     )
 
-    processor = Processor(
-        extract_root, max_depth, entropy_depth, entropy_plot, handlers
+    parameters = Parameters(
+        extract_root=extract_root,
+        max_depth=max_depth,
+        entropy_depth=entropy_depth,
+        entropy_plot=entropy_plot,
+        handlers=handlers,
     )
+    processor = Processor(parameters)
     all_reports = []
 
     def process_result(pool, result):
@@ -74,20 +80,18 @@ def process_file(
     return all_reports
 
 
+@attr.define
+class Parameters:
+    extract_root: Path
+    max_depth: int
+    entropy_depth: int
+    entropy_plot: bool
+    handlers: Handlers
+
+
 class Processor:
-    def __init__(
-        self,
-        extract_root: Path,
-        max_depth: int,
-        entropy_depth: int,
-        entropy_plot: bool,
-        handlers: Handlers,
-    ):
-        self._extract_root = extract_root
-        self._max_depth = max_depth
-        self._entropy_depth = entropy_depth
-        self._entropy_plot = entropy_plot
-        self._handlers = handlers
+    def __init__(self, parameters: Parameters):
+        self._parameters = parameters
 
     def process_task(self, task: Task) -> TaskResult:
         result = TaskResult()
@@ -105,7 +109,7 @@ class Processor:
     def _process_task(self, result: TaskResult, task: Task):
         log = logger.bind(path=task.path)
 
-        if task.depth >= self._max_depth:
+        if task.depth >= self._parameters.max_depth:
             # TODO: Use the reporting feature to warn the user (ONLY ONCE) at the end of execution, that this limit was reached.
             log.debug("Reached maximum depth, stop further processing")
             return
@@ -137,76 +141,87 @@ class Processor:
             log.debug("Ignoring empty file")
             return
 
-        self._process_regular_file(task, size, result)
+        _FileTask(self._parameters, task, size, result).process()
 
-    def _process_regular_file(self, task: Task, size: int, result: TaskResult):
-        logger.debug("Processing file", path=task.path, size=size)
-        with task.path.open("rb") as file:
+
+class _FileTask:
+    def __init__(
+        self,
+        parameters: Parameters,
+        task: Task,
+        size: int,
+        result: TaskResult,
+    ):
+        self.parameters = parameters
+        self.task = task
+        self.size = size
+        self.result = result
+
+    def process(self):
+        logger.debug("Processing file", path=self.task.path, size=self.size)
+
+        with self.task.path.open("rb") as file:
             all_chunks = search_chunks_by_priority(
-                task.path, file, size, self._handlers, result
+                self.task.path, file, self.size, self.parameters.handlers, self.result
             )
             outer_chunks = remove_inner_chunks(all_chunks)
-            unknown_chunks = calculate_unknown_chunks(outer_chunks, size)
-            if not outer_chunks and not unknown_chunks:
+            unknown_chunks = calculate_unknown_chunks(outer_chunks, self.size)
+
+            if outer_chunks or unknown_chunks:
+                self._process_chunks(file, outer_chunks, unknown_chunks)
+            else:
                 # we don't consider whole files as unknown chunks, but we still want to
                 # calculate entropy for whole files which produced no valid chunks
-                if task.depth < self._entropy_depth:
-                    calculate_entropy(task.path, draw_plot=self._entropy_plot)
-                return
+                self._calculate_entropies([self.task.path])
 
-            extract_dir = make_extract_dir(task.root, task.path, self._extract_root)
+    def _process_chunks(
+        self, file, outer_chunks: List[ValidChunk], unknown_chunks: List[UnknownChunk]
+    ):
+        extract_dir = make_extract_dir(
+            self.task.root, self.task.path, self.parameters.extract_root
+        )
 
-            carved_unknown_paths = carve_unknown_chunks(
-                extract_dir, file, unknown_chunks
-            )
-            if task.depth < self._entropy_depth:
-                for carved_unknown_path in carved_unknown_paths:
-                    calculate_entropy(carved_unknown_path, draw_plot=self._entropy_plot)
+        carved_unknown_paths = carve_unknown_chunks(extract_dir, file, unknown_chunks)
+        self._calculate_entropies(carved_unknown_paths)
 
-            for chunk in outer_chunks:
-                carved_valid_path = carve_valid_chunk(extract_dir, file, chunk)
+        for chunk in outer_chunks:
+            self._extract_chunk(extract_dir, file, chunk)
 
-                if chunk.is_encrypted:
-                    logger.warning(
-                        "Do not attempt to extract encrypted file",
-                        path=carved_valid_path,
-                        chunk=chunk,
-                    )
-                    continue
-
-                inpath, outdir = get_extract_paths(extract_dir, carved_valid_path)
-
-                extractor = chunk.handler.EXTRACTOR
-                if extractor is not None:
-                    self._extract_chunk(task, inpath, outdir, extractor, result)
+    def _calculate_entropies(self, paths: List[Path]):
+        if self.task.depth < self.parameters.entropy_depth:
+            for path in paths:
+                calculate_entropy(path, draw_plot=self.parameters.entropy_plot)
 
     def _extract_chunk(
         self,
-        task: Task,
-        inpath: Path,
-        outdir: Path,
-        extractor: Extractor,
-        result: TaskResult,
+        extract_dir: Path,
+        file,
+        chunk: ValidChunk,
     ):
-        # We only extract every blob once, it's a mistake to extract the same blog again
-        outdir.mkdir(parents=True, exist_ok=False)
+        carved_path = carve_valid_chunk(extract_dir, file, chunk)
+        inpath, outdir = get_extract_paths(extract_dir, carved_path)
+
         try:
-            extractor.extract(inpath, outdir, result)
+            chunk.extract(inpath, outdir, self.result)
+        except ExtractError:
+            # already reported & logged by extractor
+            pass
+
         except Exception as exc:
             logger.exception("Unknown error happened while extracting chunk")
-            result.add_report(UnknownError(exception=exc))
+            self.result.add_report(UnknownError(exception=exc))
 
-            return
+        # we want to get consistent partial output even in case of unforeseen problems
+        fix_extracted_directory(outdir, self.result)
 
-        fix_extracted_directory(outdir, result)
-
-        result.add_new_task(
-            Task(
-                root=self._extract_root,
-                path=outdir,
-                depth=task.depth + 1,
+        if outdir.exists():
+            self.result.add_new_task(
+                Task(
+                    root=self.parameters.extract_root,
+                    path=outdir,
+                    depth=self.task.depth + 1,
+                )
             )
-        )
 
 
 def remove_inner_chunks(chunks: List[ValidChunk]) -> List[ValidChunk]:

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -59,6 +59,7 @@ def process_file(
         entropy_depth=entropy_depth,
         entropy_plot=entropy_plot,
         handlers=handlers,
+        keep_extracted_chunks=keep_extracted_chunks,
     )
     processor = Processor(parameters)
     all_reports = []
@@ -87,6 +88,7 @@ class Parameters:
     entropy_depth: int
     entropy_plot: bool
     handlers: Handlers
+    keep_extracted_chunks: bool
 
 
 class Processor:
@@ -203,6 +205,10 @@ class _FileTask:
 
         try:
             chunk.extract(inpath, outdir, self.result)
+            if not self.parameters.keep_extracted_chunks:
+                logger.debug("Removing extracted chunk", path=inpath)
+                inpath.unlink()
+
         except ExtractError:
             # already reported & logged by extractor
             pass

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -41,6 +41,7 @@ def process_file(
     entropy_plot: bool = False,
     max_depth: int = DEFAULT_DEPTH,
     process_num: int = DEFAULT_PROCESS_NUM,
+    keep_extracted_chunks: bool = False,
     handlers: Handlers = BUILTIN_HANDLERS,
 ) -> List[Report]:
 


### PR DESCRIPTION
Fixes #261

It is not a backwards compatible change: doing the cleanup is the default, the old behavior has to be explicitly requested with `--keep-extracted-chunks` or its short version `-k`.

This is a functionally complete implementation, but it needs refactors:

- propagation of failures from `Command`s are not done with exceptions
- `_process_regular_file` fails complexity check (commit is done with skipping the pre-commit hook), so it requires breaking up. Unfortunately it looks like, it was already broken up and extracted from many times, so a bit of rethinking and introduction of new concepts/classes might be necessary
