### PR TITLE
Introduce different exit codes for the CLI

### DIFF
--- a/unblob/report.py
+++ b/unblob/report.py
@@ -1,11 +1,21 @@
+from enum import Enum
 from typing import List, Optional
 
 import attr
 
 
+class Severity(Enum):
+    """Represents possible problems encountered during execution"""
+
+    ERROR = "ERROR"
+    WARNING = "WARNING"
+
+
 @attr.define(kw_only=True)
 class Report:
     """A common base class for different reports"""
+
+    severity: Severity
 
     # Stored in `str` rather than `Handler`, because the pickle picks ups structs from `C_DEFINITIONS`
     handler: Optional[str] = None
@@ -18,6 +28,7 @@ class Report:
 class UnknownError(Report):
     """Describes an exception raised during file processing"""
 
+    severity: Severity = Severity.ERROR
     exception: Exception
 
 
@@ -32,6 +43,7 @@ class CalculateChunkExceptionReport(UnknownError):
 class ExtractCommandFailedReport(Report):
     """Describes an error when failed to run the extraction command"""
 
+    severity: Severity = Severity.WARNING
     command: str
     stdout: bytes
     stderr: bytes
@@ -42,6 +54,7 @@ class ExtractCommandFailedReport(Report):
 class ExtractorDependencyNotFoundReport(Report):
     """Describes an error when the dependency of an extractor doesn't exist"""
 
+    severity: Severity = Severity.ERROR
     dependencies: List[str]
 
 
@@ -49,5 +62,6 @@ class ExtractorDependencyNotFoundReport(Report):
 class MaliciousSymlinkRemoved(Report):
     """Describes an error when malicious symlinks have been removed from disk."""
 
+    severity: Severity = Severity.WARNING
     link: str
     target: str


### PR DESCRIPTION
Until now we had 2 exit codes:
 - 0 if everything went well
 - 1 otherwise

However we want to introduce a new "warning" level, which means there
were some issues during execution, however those issues are not
considered "fatal". We should inform the user about them, but the
possible further processing can go on without any possible issues.

For this, we introduce an `return_code` field for each `Report`, and we
exit the CLI with the most severe `return_code`.

Fixes #299 