### PR TITLE
Reusable integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ unromfs = "unblob.extractors.unromfs:cli"
 addopts = "--cov=unblob --cov=tests --cov-branch --cov-fail-under=90"
 
 [tool.vulture]
-paths = ["unblob/"]
-exclude = ["unblob/_py/"]
+paths = ["unblob/" ]
+exclude = ["unblob/_py/", "unblob/testing.py"]
 ignore_names = ["breakpointhook", "context_class", "hookimpl"]
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,6 @@
-from pathlib import Path
-
-import pytest
-from pytest_cov.embed import cleanup_on_sigterm
-
 from unblob.extractors import Command
-from unblob.logging import configure_logger
 from unblob.models import Handler
-
-
-@pytest.fixture(scope="session", autouse=True)
-def configure_logging():
-    configure_logger(verbosity_level=3, extract_root=Path(""))
-
-    # https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html#if-you-use-multiprocessing-process
-    cleanup_on_sigterm()
+from unblob.testing import configure_logging  # noqa: F401 (module imported but unused)
 
 
 class TestHandler(Handler):

--- a/unblob/cli.py
+++ b/unblob/cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import itertools
 import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -27,10 +26,11 @@ def show_external_dependencies(
 
     plugin_manager = ctx.params["plugin_manager"]
     handlers = ctx.params["handlers"]
-    plugins = ctx.params.get(
+    plugins_path = ctx.params.get(
         "plugins_path"
     )  # may not exist, depends on parameter order...
-    handlers = add_handlers_from_plugins(plugin_manager, handlers, plugins)
+    plugin_manager.import_plugins(plugins_path)
+    handlers = plugin_manager.extend_handlers_from_plugins(handlers)
 
     dependencies = get_dependencies(handlers)
     text = pretty_format_dependencies(dependencies)
@@ -38,29 +38,6 @@ def show_external_dependencies(
 
     click.echo(text)
     ctx.exit(code=exit_code)
-
-
-def add_handlers_from_plugins(
-    plugin_manager: UnblobPluginManager,
-    handlers: Handlers,
-    plugin_path: Optional[Path],
-):
-    if plugin_path:
-        plugin_manager.import_path(plugin_path)
-
-    plugin_manager.load_setuptools_entrypoints()
-
-    plugins = [name for name, _plugin in plugin_manager.list_name_plugin()]
-    if not plugins:
-        return handlers
-
-    logger.info("Loaded plugins", plugins=plugins)
-
-    extra_handlers = list(itertools.chain(*plugin_manager.hook.unblob_register_handlers()))  # type: ignore
-
-    logger.debug("Loaded handlers from plugins", handlers=extra_handlers)
-
-    return handlers.with_prepended(extra_handlers)
 
 
 def get_help_text():
@@ -164,7 +141,8 @@ def cli(
 ) -> List[Report]:
     configure_logger(verbose, extract_root)
 
-    handlers = add_handlers_from_plugins(plugin_manager, handlers, plugins_path)
+    plugin_manager.import_plugins(plugins_path)
+    handlers = plugin_manager.extend_handlers_from_plugins(handlers)
 
     logger.info("Start processing files", count=noformat(len(files)))
     all_reports = []

--- a/unblob/cli.py
+++ b/unblob/cli.py
@@ -160,7 +160,7 @@ def cli(
     verbose: int,
     plugins_path: Optional[Path],
     handlers: Handlers,
-    plugin_manager,
+    plugin_manager: UnblobPluginManager,
 ) -> List[Report]:
     configure_logger(verbose, extract_root)
 

--- a/unblob/testing.py
+++ b/unblob/testing.py
@@ -1,0 +1,68 @@
+import shlex
+import subprocess
+from pathlib import Path
+from typing import List
+
+import pytest
+from pytest_cov.embed import cleanup_on_sigterm
+
+from unblob.logging import configure_logger
+from unblob.report import Report
+
+
+@pytest.fixture(scope="session", autouse=True)
+def configure_logging():
+    configure_logger(verbosity_level=3, extract_root=Path(""))
+
+    # https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html#if-you-use-multiprocessing-process
+    cleanup_on_sigterm()
+
+
+def gather_integration_tests(test_data_path: Path):
+    test_input_dirs = list(test_data_path.glob("**/__input__"))
+    test_case_dirs = [p.parent for p in test_input_dirs]
+    test_output_dirs = [p / "__output__" for p in test_case_dirs]
+    test_ids = [
+        f"{str(p.relative_to(test_data_path)).replace('/', '.')}"
+        for p in test_case_dirs
+    ]
+
+    for input_dir in test_input_dirs:
+        assert (
+            list(input_dir.iterdir()) != []
+        ), f"Integration test input dir should contain at least 1 file: {input_dir}"
+
+    return pytest.mark.parametrize(
+        "input_dir, output_dir", zip(test_input_dirs, test_output_dirs), ids=test_ids
+    )
+
+
+def check_output_is_the_same(reference_dir: Path, extract_dir: Path):
+    __tracebackhide__ = True
+
+    diff_command = [
+        "diff",
+        "--recursive",
+        "--unified",
+        # fix for potential symlinks
+        "--no-dereference",
+        # Non-unicode files would produce garbage output
+        # showing file names which are different should be helpful
+        "--brief",
+        "--exclude",
+        ".gitkeep",
+        str(reference_dir),
+        str(extract_dir),
+    ]
+
+    try:
+        subprocess.run(diff_command, capture_output=True, check=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        runnable_diff_command = shlex.join(diff_command)
+        pytest.fail(f"\nDiff command: {runnable_diff_command}\n{exc.stdout}\n")
+
+
+def check_reports(reports: List[Report]):
+    __tracebackhide__ = True
+
+    assert reports == [], "Unexpected error reports"


### PR DESCRIPTION
The idea behind this change is to make it able to reuse the
integration tests in external handlers like this:

    @gather_integration_tests(TEST_DATA_PATH)
    def test_all_handlers(input_dir, output_dir, tmp_path):
        handlers = Handlers([(MyHandler,)])
        all_reports = process_file(
            path=input_dir,
            extract_root=tmp_path,
            entropy_depth=0,
            handlers=handlers
        )

        check_output_is_the_same(output_dir, tmp_path)
        check_reports(all_reports)
