### PR TITLE
test_handlers: make integration test parametrization more obvious

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -26,7 +26,9 @@ TEST_DATA_PATH = Path(__file__).parent / "integration"
 HANDLERS_PACKAGE_PATH = Path(handlers.__file__).parent
 
 
-@gather_integration_tests(TEST_DATA_PATH)
+@pytest.mark.parametrize(
+    "input_dir, output_dir", gather_integration_tests(TEST_DATA_PATH)
+)
 def test_all_handlers(input_dir: Path, output_dir: Path, tmp_path: Path):
     all_reports = process_file(
         path=input_dir,

--- a/unblob/testing.py
+++ b/unblob/testing.py
@@ -27,14 +27,14 @@ def gather_integration_tests(test_data_path: Path):
         for p in test_case_dirs
     ]
 
-    for input_dir in test_input_dirs:
+    for input_dir, output_dir, test_id in zip(
+        test_input_dirs, test_output_dirs, test_ids
+    ):
         assert (
             list(input_dir.iterdir()) != []
         ), f"Integration test input dir should contain at least 1 file: {input_dir}"
 
-    return pytest.mark.parametrize(
-        "input_dir, output_dir", zip(test_input_dirs, test_output_dirs), ids=test_ids
-    )
+        yield pytest.param(input_dir, output_dir, id=test_id)
 
 
 def check_output_is_the_same(reference_dir: Path, extract_dir: Path):


### PR DESCRIPTION
`@gather_integration_tests` calling `@pytest.mark.parametrize` under
the hood was confusing, now it is turned inside out.