### PR TITLE
plugins: reorganize handler loading from plugins

### DIFF
--- a/unblob/cli.py
+++ b/unblob/cli.py
@@ -25,12 +25,12 @@ def show_external_dependencies(
         return
 
     plugin_manager = ctx.params["plugin_manager"]
-    handlers = ctx.params["handlers"]
     plugins_path = ctx.params.get(
         "plugins_path"
     )  # may not exist, depends on parameter order...
     plugin_manager.import_plugins(plugins_path)
-    handlers = plugin_manager.extend_handlers_from_plugins(handlers)
+    extra_handlers = plugin_manager.load_handlers_from_plugins()
+    handlers = ctx.params["handlers"].with_prepended(extra_handlers)
 
     dependencies = get_dependencies(handlers)
     text = pretty_format_dependencies(dependencies)
@@ -142,7 +142,8 @@ def cli(
     configure_logger(verbose, extract_root)
 
     plugin_manager.import_plugins(plugins_path)
-    handlers = plugin_manager.extend_handlers_from_plugins(handlers)
+    extra_handlers = plugin_manager.load_handlers_from_plugins()
+    handlers = handlers.with_prepended(extra_handlers)
 
     logger.info("Start processing files", count=noformat(len(files)))
     all_reports = []

--- a/unblob/models.py
+++ b/unblob/models.py
@@ -187,6 +187,9 @@ class Handlers:
         self._flat = [h for handlers in by_priority for h in handlers]
 
     def with_prepended(self, by_priority):
+        if not by_priority:
+            # No additions
+            return self
         return Handlers([tuple(by_priority)] + self._by_priority)
 
     @property

--- a/unblob/plugins.py
+++ b/unblob/plugins.py
@@ -93,14 +93,11 @@ class UnblobPluginManager(pluggy.PluginManager):
 
         logger.info("Loaded plugins", plugins=plugins)
 
-    def extend_handlers_from_plugins(
+    def load_handlers_from_plugins(
         self,
-        handlers: Handlers,
-    ) -> Handlers:
+    ) -> List[Handlers]:
         extra_handlers = list(itertools.chain(*self.hook.unblob_register_handlers()))  # type: ignore
-        if not extra_handlers:
-            return handlers
+        if extra_handlers:
+            logger.debug("Loaded handlers from plugins", handlers=extra_handlers)
 
-        logger.debug("Loaded handlers from plugins", handlers=extra_handlers)
-
-        return handlers.with_prepended(extra_handlers)
+        return extra_handlers


### PR DESCRIPTION
Now every method does only one thing:
 - `import_plugins`: loads the actual plugins
 - `load_handlers_from_plugins`: gathers registered plugins
 - `handlers.with_prepended`: combine internal builtin handlers with the
   just loaded ones