### PR TITLE
Refactor Parameters -> ExtractionConfig, process_file

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -15,7 +15,7 @@ import pytest
 
 from unblob import handlers
 from unblob.models import Handler
-from unblob.processing import process_file
+from unblob.processing import ExtractionConfig, process_file
 from unblob.testing import (
     check_output_is_the_same,
     check_reports,
@@ -30,12 +30,12 @@ HANDLERS_PACKAGE_PATH = Path(handlers.__file__).parent
     "input_dir, output_dir", gather_integration_tests(TEST_DATA_PATH)
 )
 def test_all_handlers(input_dir: Path, output_dir: Path, tmp_path: Path):
-    all_reports = process_file(
-        path=input_dir,
+    config = ExtractionConfig(
         extract_root=tmp_path,
         entropy_depth=0,
         keep_extracted_chunks=True,
     )
+    all_reports = process_file(config, path=input_dir)
 
     check_output_is_the_same(output_dir, tmp_path)
     check_reports(all_reports)

--- a/unblob/cli.py
+++ b/unblob/cli.py
@@ -13,7 +13,12 @@ from .cli_options import verbosity_option
 from .dependencies import get_dependencies, pretty_format_dependencies
 from .handlers import BUILTIN_HANDLERS, Handlers
 from .logging import configure_logger, noformat
-from .processing import DEFAULT_DEPTH, DEFAULT_PROCESS_NUM, process_file
+from .processing import (
+    DEFAULT_DEPTH,
+    DEFAULT_PROCESS_NUM,
+    ExtractionConfig,
+    process_file,
+)
 
 logger = get_logger()
 
@@ -154,19 +159,20 @@ def cli(
     extra_handlers = plugin_manager.load_handlers_from_plugins()
     handlers = handlers.with_prepended(extra_handlers)
 
+    config = ExtractionConfig(
+        extract_root=extract_root,
+        max_depth=depth,
+        entropy_depth=entropy_depth,
+        entropy_plot=bool(verbose >= 3),
+        process_num=process_num,
+        handlers=handlers,
+        keep_extracted_chunks=keep_extracted_chunks,
+    )
+
     logger.info("Start processing files", count=noformat(len(files)))
     all_reports = []
     for path in files:
-        report = process_file(
-            path,
-            extract_root,
-            max_depth=depth,
-            entropy_depth=entropy_depth,
-            entropy_plot=bool(verbose >= 3),
-            process_num=process_num,
-            handlers=handlers,
-            keep_extracted_chunks=keep_extracted_chunks,
-        )
+        report = process_file(config, path)
         all_reports.extend(report)
     return all_reports
 

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -34,27 +34,19 @@ DEFAULT_DEPTH = 10
 DEFAULT_PROCESS_NUM = multiprocessing.cpu_count()
 
 
-@attr.define
+@attr.define(kw_only=True)
 class ExtractionConfig:
     extract_root: Path
-    max_depth: int
     entropy_depth: int
-    entropy_plot: bool
-    handlers: Handlers
-    keep_extracted_chunks: bool
+    entropy_plot: bool = False
+    max_depth: int = DEFAULT_DEPTH
+    process_num: int = DEFAULT_PROCESS_NUM
+    keep_extracted_chunks: bool = False
+    handlers: Handlers = BUILTIN_HANDLERS
 
 
 @terminate_gracefully
-def process_file(
-    path: Path,
-    extract_root: Path,
-    entropy_depth: int,
-    entropy_plot: bool = False,
-    max_depth: int = DEFAULT_DEPTH,
-    process_num: int = DEFAULT_PROCESS_NUM,
-    keep_extracted_chunks: bool = False,
-    handlers: Handlers = BUILTIN_HANDLERS,
-) -> List[Report]:
+def process_file(config: ExtractionConfig, path: Path) -> List[Report]:
 
     root = path if path.is_dir() else path.parent
     root_task = Task(
@@ -63,14 +55,6 @@ def process_file(
         depth=0,
     )
 
-    config = ExtractionConfig(
-        extract_root=extract_root,
-        max_depth=max_depth,
-        entropy_depth=entropy_depth,
-        entropy_plot=entropy_plot,
-        handlers=handlers,
-        keep_extracted_chunks=keep_extracted_chunks,
-    )
     processor = Processor(config)
     all_reports = []
 
@@ -80,7 +64,7 @@ def process_file(
         all_reports.extend(result.reports)
 
     pool = make_pool(
-        process_num=process_num,
+        process_num=config.process_num,
         handler=processor.process_task,
         result_callback=process_result,
     )


### PR DESCRIPTION
Convert many parameters of `process_file` into `ExtractionConfig` and thus simplify its signature to
```py
def process_file(config: ExtractionConfig, path: Path) -> List[Report]:
```

----

With this change, we are few steps from this interface:
```py
Unblob(**extraction_parameters).process_file(path)
```
