### PR TITLE
Fix XZ overall_size calculation.

### DIFF
--- a/tests/integration/compression/xz/__input__/multiblock.padded.xz
+++ b/tests/integration/compression/xz/__input__/multiblock.padded.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0856a2ca40f1b89f1f6b1e7d35b45d68eb8cd71132c9f77ea2a46e1348d8436c
+size 2168

--- a/tests/integration/compression/xz/__output__/multiblock.padded.xz_extract/0-2168.xz
+++ b/tests/integration/compression/xz/__output__/multiblock.padded.xz_extract/0-2168.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0856a2ca40f1b89f1f6b1e7d35b45d68eb8cd71132c9f77ea2a46e1348d8436c
+size 2168

--- a/tests/integration/compression/xz/__output__/multiblock.padded.xz_extract/0-2168.xz_extract/0-2168
+++ b/tests/integration/compression/xz/__output__/multiblock.padded.xz_extract/0-2168.xz_extract/0-2168
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d70de5e50212e660ffabf1a3e54fa406b54c8cd9c9b65b68d39a4e3e4d4df2f
+size 2048

--- a/unblob/handlers/compression/xz.py
+++ b/unblob/handlers/compression/xz.py
@@ -101,7 +101,7 @@ class XZHandler(Handler):
                 size, _ = read_multibyte_int(file)
                 index_size += size
 
-                blocks_size += unpadded_size
+                blocks_size += round_up(unpadded_size, XZ_PADDING)
 
             index_size += CRC32_LEN
 


### PR DESCRIPTION
The idea of the XZ handler is to identify the end of a chunk by finding its footer with a string search. Then it validates that this chunk is right by parsing the XZ records to calculate the overall_size value. If both values correspond, we have a valid chunk.

There was an error in the overall_size calculation given that we incremented by unpadded size of each record while we should increment by the padded size of each record.

This commit fix this issue by incrementing by padded sizes.

Fix #310