### PR TITLE
Fix LZO to handle missing checksum and multi-block files

### DIFF
--- a/tests/integration/compression/lzo/__input__/lorem.adler.checksum.filter.multi-block.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.checksum.filter.multi-block.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1abbbad17e7cd7797cfb39456491ae475964f29d2593ba6156e00ead5a30ec93
+size 29563

--- a/tests/integration/compression/lzo/__input__/lorem.adler.checksum.filter.multi-block.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.checksum.filter.multi-block.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:393a4d16ffb51f3c57f59ea7757bd43f6a4ecddf04fb3466cbe07eece4d38443
+size 29552

--- a/tests/integration/compression/lzo/__input__/lorem.adler.checksum.filter.multi-file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.checksum.filter.multi-file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5eebc3f76561aeee03d03b3e5e7b3e304e0a4472fe3200cb84186ebbe1579b4e
+size 33904

--- a/tests/integration/compression/lzo/__input__/lorem.adler.checksum.filter.simple.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.checksum.filter.simple.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:426d9ae4da14218e19762e60b6bbe725cceda268e0f9928bc5dbf5faa5540936
+size 4341

--- a/tests/integration/compression/lzo/__input__/lorem.adler.checksum.filter.simple.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.checksum.filter.simple.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c94cb829cb19ac0638843ae589751a86f004b77efc13396f592ae71434c4146
+size 4332

--- a/tests/integration/compression/lzo/__input__/lorem.adler.checksum.no-filter.multi-block.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.checksum.no-filter.multi-block.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61c2985578d8a5bc1373dc8b2eb5b9994f0d96adc0dfa8b5bd589c4865db1cfd
+size 26504

--- a/tests/integration/compression/lzo/__input__/lorem.adler.checksum.no-filter.multi-block.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.checksum.no-filter.multi-block.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c7bca3a6931885ecd267b7b590fb07c58454bd6b2ea2da4a6fbe0966b46cb88
+size 26493

--- a/tests/integration/compression/lzo/__input__/lorem.adler.checksum.no-filter.multi-file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.checksum.no-filter.multi-file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73dba7dd292a9f364c5ab82655c5b566da1defa534fa7eebe0b587c9e7465eb1
+size 30437

--- a/tests/integration/compression/lzo/__input__/lorem.adler.checksum.no-filter.simple.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.checksum.no-filter.simple.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:697effcea2d396ef729eb5e4332ce07b9fdc950e1537500ffd668b17dc5b9b33
+size 3933

--- a/tests/integration/compression/lzo/__input__/lorem.adler.checksum.no-filter.simple.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.checksum.no-filter.simple.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94e4034e3b10c3c7ce35aa19de73c20467a7219ce4aae5389a681d5c4af7250b
+size 3924

--- a/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.filter.multi-block.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.filter.multi-block.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e8de0059a998cd8c420aa3b174c23589de0e847feb6a8dae50ae1f38cdd0a96
+size 29555

--- a/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.filter.multi-block.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.filter.multi-block.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:109210635aa01328fbd2430a4b9e357f05b1af5ed7f15ea9a43b8bbac5ce7d7f
+size 29544

--- a/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.filter.multi-file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.filter.multi-file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84b627752688f70700ed2b010bac112e83cfa132b4caf7a15e578fa729f811d2
+size 33892

--- a/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.filter.simple.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.filter.simple.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77ebf487dc139f07c9c82b4c42c1c1454be881bae96797b4d8b3cbbb094132ea
+size 4337

--- a/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.filter.simple.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.filter.simple.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:984414dc7ad12aa77892cc3084dfef0798d2c16368e0c15aeb616b598c6c3c03
+size 4328

--- a/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.no-filter.multi-block.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.no-filter.multi-block.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c91a9d1f537c856e3762354c0f98293515ddaeea78584027e6476556d88fb09f
+size 26496

--- a/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.no-filter.multi-block.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.no-filter.multi-block.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4bb40768094fb8321326a5f1b4995b24d7c9d3a09f075b34f06f91b05623c79
+size 26485

--- a/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.no-filter.multi-file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.no-filter.multi-file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8ef81dc09619b6b8a46d4d87d92dc18cad09344c6765f6cc6f8c31c3de5a08d
+size 30425

--- a/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.no-filter.simple.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.no-filter.simple.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf8b6357674ddfb0b5acd6235ebe27739ff3a469c7d0aa8c17a1a4eb1cf5d513
+size 3929

--- a/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.no-filter.simple.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.adler.no-checksum.no-filter.simple.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c6ba5380b25eec121a749c96fce8a274333358016443584f5afad25ebb85c86
+size 3920

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.filter.multi-block.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.filter.multi-block.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23418cf1fc9cdee8ff830f9f813b79b7928f3294ebe5c60dad084aa276c82b25
+size 29563

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.filter.multi-block.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.filter.multi-block.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dd871103d2e271734fa42aefa998b11652212483e8fd77f8149f57eb666ef02
+size 29552

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.filter.multi-file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.filter.multi-file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:becd5035297b9fa79eddd331d2c5c4da9106f535e4082be25824df9a81b60961
+size 33904

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.filter.simple.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.filter.simple.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17fc219db084d5bffca8d1c561c774a4f7829cf6925c233bd4f45a54aeea6d00
+size 4341

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.filter.simple.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.filter.simple.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af949ad1fd4f5b0e5c1197cc87a5622d3eb56a88a3f141818b00aefb5de1ad85
+size 4332

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.no-filter.multi-block.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.no-filter.multi-block.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fa9a110c9e701a9ec7ad8a8ba0833c66810cc745732278dca5dded3409e2535
+size 26504

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.no-filter.multi-block.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.no-filter.multi-block.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e60f885e6229ed84dbee1596533d884c9cc26826707e278441300eeaf5c6936b
+size 26493

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.no-filter.multi-file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.no-filter.multi-file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:327a5e5e015764968ec9fd49085cbdb0a396189424dbb95bf0e2c05c0bd7189b
+size 30437

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.no-filter.simple.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.no-filter.simple.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e52ebeb5264726d0d91f14161a55ae410aff4de05500ebf6db81f1b4397c330e
+size 3933

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.no-filter.simple.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.checksum.no-filter.simple.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96a7d15a2b83aa92af9ba906bb3e5eaf40235f3f231119d6e12377d065d8f183
+size 3924

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.filter.multi-block.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.filter.multi-block.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bc7216558ef0abc7aeedf04d59dcdb77eeaed1b459d1c7ff6b3e91e9e28115a
+size 29555

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.filter.multi-block.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.filter.multi-block.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b242ac69370b74ca087782e18058444f9cac1ce5813ede3e42074d7797bd8e5
+size 29544

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.filter.multi-file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.filter.multi-file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:131d031e2e6da1c3b52c7f349d031db621e6d52862754edbb1db59211791ec21
+size 33892

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.filter.simple.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.filter.simple.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53842103ec1b4e88518c7696ed87ae854baf965452fcd71cdd57707c66b43a5a
+size 4337

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.filter.simple.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.filter.simple.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:291c172d45bf33eec2bf1ad7b33913e32eac8c129041ec6a5fea39fe6ee9f569
+size 4328

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.no-filter.multi-block.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.no-filter.multi-block.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:079e3ffdee84712d90ef20576c62ba10005c4730eb9b1544da9e823452ada609
+size 26496

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.no-filter.multi-block.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.no-filter.multi-block.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1e581e7c125348fc64d17318e5fd581337601d8cc5b25662f7d3af5b7d6e62a
+size 26485

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.no-filter.multi-file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.no-filter.multi-file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc82a5371d0d57758bc5eaa67711ae1da460699e974d2b729b4876658b6f7391
+size 30425

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.no-filter.simple.file.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.no-filter.simple.file.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:206c895a3ccd906487078fe288115d3896db7339653fa7052d9952c9a160d1fc
+size 3929

--- a/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.no-filter.simple.stdin.lzo
+++ b/tests/integration/compression/lzo/__input__/lorem.crc32.no-checksum.no-filter.simple.stdin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b81386ecfbdea5cd8299ac231259dd084333e1a6cd8899a403772228e1126db2
+size 3920

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-block.file.lzo_extract/0-29563.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-block.file.lzo_extract/0-29563.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1abbbad17e7cd7797cfb39456491ae475964f29d2593ba6156e00ead5a30ec93
+size 29563

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-block.file.lzo_extract/0-29563.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-block.file.lzo_extract/0-29563.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-block.stdin.lzo_extract/0-29552.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-block.stdin.lzo_extract/0-29552.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:393a4d16ffb51f3c57f59ea7757bd43f6a4ecddf04fb3466cbe07eece4d38443
+size 29552

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-block.stdin.lzo_extract/0-29552.lzo_extract/0-29552
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-block.stdin.lzo_extract/0-29552.lzo_extract/0-29552
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-file.lzo_extract/0-4341.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-file.lzo_extract/0-4341.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2012c6c813cd828da219d66416d63fe827c9b35455a424e97f3ad5e505e9c7a3
+size 4341

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-file.lzo_extract/0-4341.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-file.lzo_extract/0-4341.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-file.lzo_extract/4341-33904.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-file.lzo_extract/4341-33904.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfa6c3c88af0f5a728782d7fd0f913cbd270dd1267902afeffd972969606b147
+size 29563

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-file.lzo_extract/4341-33904.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.multi-file.lzo_extract/4341-33904.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.simple.file.lzo_extract/0-4341.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.simple.file.lzo_extract/0-4341.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:426d9ae4da14218e19762e60b6bbe725cceda268e0f9928bc5dbf5faa5540936
+size 4341

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.simple.file.lzo_extract/0-4341.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.simple.file.lzo_extract/0-4341.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.simple.stdin.lzo_extract/0-4332.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.simple.stdin.lzo_extract/0-4332.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c94cb829cb19ac0638843ae589751a86f004b77efc13396f592ae71434c4146
+size 4332

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.simple.stdin.lzo_extract/0-4332.lzo_extract/0-4332
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.filter.simple.stdin.lzo_extract/0-4332.lzo_extract/0-4332
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-block.file.lzo_extract/0-26504.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-block.file.lzo_extract/0-26504.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61c2985578d8a5bc1373dc8b2eb5b9994f0d96adc0dfa8b5bd589c4865db1cfd
+size 26504

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-block.file.lzo_extract/0-26504.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-block.file.lzo_extract/0-26504.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-block.stdin.lzo_extract/0-26493.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-block.stdin.lzo_extract/0-26493.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c7bca3a6931885ecd267b7b590fb07c58454bd6b2ea2da4a6fbe0966b46cb88
+size 26493

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-block.stdin.lzo_extract/0-26493.lzo_extract/0-26493
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-block.stdin.lzo_extract/0-26493.lzo_extract/0-26493
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-file.lzo_extract/0-3933.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-file.lzo_extract/0-3933.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d5d22dbd13b1324ade111b237cd0d84aa952620e8a1ae66a77a12b02573c169
+size 3933

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-file.lzo_extract/0-3933.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-file.lzo_extract/0-3933.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-file.lzo_extract/3933-30437.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-file.lzo_extract/3933-30437.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94526d97167c5421a6ddbd8b4812814ad07c11be6e937d8db09b613dd1bd52a5
+size 26504

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-file.lzo_extract/3933-30437.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.multi-file.lzo_extract/3933-30437.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.simple.file.lzo_extract/0-3933.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.simple.file.lzo_extract/0-3933.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:697effcea2d396ef729eb5e4332ce07b9fdc950e1537500ffd668b17dc5b9b33
+size 3933

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.simple.file.lzo_extract/0-3933.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.simple.file.lzo_extract/0-3933.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.simple.stdin.lzo_extract/0-3924.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.simple.stdin.lzo_extract/0-3924.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94e4034e3b10c3c7ce35aa19de73c20467a7219ce4aae5389a681d5c4af7250b
+size 3924

--- a/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.simple.stdin.lzo_extract/0-3924.lzo_extract/0-3924
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.checksum.no-filter.simple.stdin.lzo_extract/0-3924.lzo_extract/0-3924
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-block.file.lzo_extract/0-29555.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-block.file.lzo_extract/0-29555.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e8de0059a998cd8c420aa3b174c23589de0e847feb6a8dae50ae1f38cdd0a96
+size 29555

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-block.file.lzo_extract/0-29555.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-block.file.lzo_extract/0-29555.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-block.stdin.lzo_extract/0-29544.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-block.stdin.lzo_extract/0-29544.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:109210635aa01328fbd2430a4b9e357f05b1af5ed7f15ea9a43b8bbac5ce7d7f
+size 29544

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-block.stdin.lzo_extract/0-29544.lzo_extract/0-29544
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-block.stdin.lzo_extract/0-29544.lzo_extract/0-29544
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-file.lzo_extract/0-4337.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-file.lzo_extract/0-4337.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b63c52d2eb01cbfb68c4ebe6626b8d5b1f0faba4aff4e45ac6f4f66d6e95a8b
+size 4337

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-file.lzo_extract/0-4337.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-file.lzo_extract/0-4337.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-file.lzo_extract/4337-33892.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-file.lzo_extract/4337-33892.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa46d24f5a7f909f8167c35a1c11dbadc3c561a28e6d5f11e16d7bcfc1313d56
+size 29555

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-file.lzo_extract/4337-33892.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.multi-file.lzo_extract/4337-33892.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.simple.file.lzo_extract/0-4337.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.simple.file.lzo_extract/0-4337.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77ebf487dc139f07c9c82b4c42c1c1454be881bae96797b4d8b3cbbb094132ea
+size 4337

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.simple.file.lzo_extract/0-4337.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.simple.file.lzo_extract/0-4337.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.simple.stdin.lzo_extract/0-4328.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.simple.stdin.lzo_extract/0-4328.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:984414dc7ad12aa77892cc3084dfef0798d2c16368e0c15aeb616b598c6c3c03
+size 4328

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.simple.stdin.lzo_extract/0-4328.lzo_extract/0-4328
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.filter.simple.stdin.lzo_extract/0-4328.lzo_extract/0-4328
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-block.file.lzo_extract/0-26496.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-block.file.lzo_extract/0-26496.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c91a9d1f537c856e3762354c0f98293515ddaeea78584027e6476556d88fb09f
+size 26496

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-block.file.lzo_extract/0-26496.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-block.file.lzo_extract/0-26496.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-block.stdin.lzo_extract/0-26485.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-block.stdin.lzo_extract/0-26485.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4bb40768094fb8321326a5f1b4995b24d7c9d3a09f075b34f06f91b05623c79
+size 26485

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-block.stdin.lzo_extract/0-26485.lzo_extract/0-26485
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-block.stdin.lzo_extract/0-26485.lzo_extract/0-26485
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-file.lzo_extract/0-3929.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-file.lzo_extract/0-3929.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e8554bb19e6c59152a76fdbbce6a942e57eba3fa09c1eb1c412823706bee3e5
+size 3929

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-file.lzo_extract/0-3929.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-file.lzo_extract/0-3929.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-file.lzo_extract/3929-30425.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-file.lzo_extract/3929-30425.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fff7b8fee7bac291b829de575beb8c8dcf974b4a8f3e43d2b379c40284c9e4e
+size 26496

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-file.lzo_extract/3929-30425.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.multi-file.lzo_extract/3929-30425.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.simple.file.lzo_extract/0-3929.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.simple.file.lzo_extract/0-3929.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf8b6357674ddfb0b5acd6235ebe27739ff3a469c7d0aa8c17a1a4eb1cf5d513
+size 3929

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.simple.file.lzo_extract/0-3929.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.simple.file.lzo_extract/0-3929.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.simple.stdin.lzo_extract/0-3920.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.simple.stdin.lzo_extract/0-3920.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c6ba5380b25eec121a749c96fce8a274333358016443584f5afad25ebb85c86
+size 3920

--- a/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.simple.stdin.lzo_extract/0-3920.lzo_extract/0-3920
+++ b/tests/integration/compression/lzo/__output__/lorem.adler.no-checksum.no-filter.simple.stdin.lzo_extract/0-3920.lzo_extract/0-3920
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-block.file.lzo_extract/0-29563.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-block.file.lzo_extract/0-29563.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23418cf1fc9cdee8ff830f9f813b79b7928f3294ebe5c60dad084aa276c82b25
+size 29563

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-block.file.lzo_extract/0-29563.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-block.file.lzo_extract/0-29563.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-block.stdin.lzo_extract/0-29552.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-block.stdin.lzo_extract/0-29552.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dd871103d2e271734fa42aefa998b11652212483e8fd77f8149f57eb666ef02
+size 29552

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-block.stdin.lzo_extract/0-29552.lzo_extract/0-29552
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-block.stdin.lzo_extract/0-29552.lzo_extract/0-29552
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-file.lzo_extract/0-4341.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-file.lzo_extract/0-4341.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0a48f0cf61f51a4cbaec399c48ce5baae3917831c6aa913c60a920196c5460c
+size 4341

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-file.lzo_extract/0-4341.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-file.lzo_extract/0-4341.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-file.lzo_extract/4341-33904.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-file.lzo_extract/4341-33904.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6983230a00061acf84a04c8217bb0b7631fe2c88ab8a10f291eb10554dc2c6b
+size 29563

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-file.lzo_extract/4341-33904.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.multi-file.lzo_extract/4341-33904.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.simple.file.lzo_extract/0-4341.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.simple.file.lzo_extract/0-4341.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17fc219db084d5bffca8d1c561c774a4f7829cf6925c233bd4f45a54aeea6d00
+size 4341

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.simple.file.lzo_extract/0-4341.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.simple.file.lzo_extract/0-4341.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.simple.stdin.lzo_extract/0-4332.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.simple.stdin.lzo_extract/0-4332.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af949ad1fd4f5b0e5c1197cc87a5622d3eb56a88a3f141818b00aefb5de1ad85
+size 4332

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.simple.stdin.lzo_extract/0-4332.lzo_extract/0-4332
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.filter.simple.stdin.lzo_extract/0-4332.lzo_extract/0-4332
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-block.file.lzo_extract/0-26504.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-block.file.lzo_extract/0-26504.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fa9a110c9e701a9ec7ad8a8ba0833c66810cc745732278dca5dded3409e2535
+size 26504

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-block.file.lzo_extract/0-26504.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-block.file.lzo_extract/0-26504.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-block.stdin.lzo_extract/0-26493.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-block.stdin.lzo_extract/0-26493.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e60f885e6229ed84dbee1596533d884c9cc26826707e278441300eeaf5c6936b
+size 26493

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-block.stdin.lzo_extract/0-26493.lzo_extract/0-26493
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-block.stdin.lzo_extract/0-26493.lzo_extract/0-26493
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-file.lzo_extract/0-3933.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-file.lzo_extract/0-3933.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5d9e8639ad9b59d4319b62e0c4b3c8d8d7b3ebd1805caceabd921bae253d352
+size 3933

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-file.lzo_extract/0-3933.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-file.lzo_extract/0-3933.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-file.lzo_extract/3933-30437.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-file.lzo_extract/3933-30437.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84d88f484d03a81b5de64a3238d5f7d59b48b17e264048be08ae3b256685dd98
+size 26504

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-file.lzo_extract/3933-30437.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.multi-file.lzo_extract/3933-30437.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.simple.file.lzo_extract/0-3933.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.simple.file.lzo_extract/0-3933.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e52ebeb5264726d0d91f14161a55ae410aff4de05500ebf6db81f1b4397c330e
+size 3933

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.simple.file.lzo_extract/0-3933.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.simple.file.lzo_extract/0-3933.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.simple.stdin.lzo_extract/0-3924.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.simple.stdin.lzo_extract/0-3924.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96a7d15a2b83aa92af9ba906bb3e5eaf40235f3f231119d6e12377d065d8f183
+size 3924

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.simple.stdin.lzo_extract/0-3924.lzo_extract/0-3924
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.checksum.no-filter.simple.stdin.lzo_extract/0-3924.lzo_extract/0-3924
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-block.file.lzo_extract/0-29555.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-block.file.lzo_extract/0-29555.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bc7216558ef0abc7aeedf04d59dcdb77eeaed1b459d1c7ff6b3e91e9e28115a
+size 29555

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-block.file.lzo_extract/0-29555.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-block.file.lzo_extract/0-29555.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-block.stdin.lzo_extract/0-29544.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-block.stdin.lzo_extract/0-29544.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b242ac69370b74ca087782e18058444f9cac1ce5813ede3e42074d7797bd8e5
+size 29544

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-block.stdin.lzo_extract/0-29544.lzo_extract/0-29544
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-block.stdin.lzo_extract/0-29544.lzo_extract/0-29544
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-file.lzo_extract/0-4337.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-file.lzo_extract/0-4337.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8b8a0c9bb4799c83c1622270396f39d2f453d0007a2dc07c07e4e240111b7a8
+size 4337

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-file.lzo_extract/0-4337.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-file.lzo_extract/0-4337.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-file.lzo_extract/4337-33892.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-file.lzo_extract/4337-33892.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81c720e4804b20e3dcb8cfb4ff1d7ce28d840062faa392f9484ed38324359d96
+size 29555

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-file.lzo_extract/4337-33892.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.multi-file.lzo_extract/4337-33892.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.simple.file.lzo_extract/0-4337.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.simple.file.lzo_extract/0-4337.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53842103ec1b4e88518c7696ed87ae854baf965452fcd71cdd57707c66b43a5a
+size 4337

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.simple.file.lzo_extract/0-4337.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.simple.file.lzo_extract/0-4337.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.simple.stdin.lzo_extract/0-4328.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.simple.stdin.lzo_extract/0-4328.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:291c172d45bf33eec2bf1ad7b33913e32eac8c129041ec6a5fea39fe6ee9f569
+size 4328

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.simple.stdin.lzo_extract/0-4328.lzo_extract/0-4328
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.filter.simple.stdin.lzo_extract/0-4328.lzo_extract/0-4328
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-block.file.lzo_extract/0-26496.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-block.file.lzo_extract/0-26496.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:079e3ffdee84712d90ef20576c62ba10005c4730eb9b1544da9e823452ada609
+size 26496

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-block.file.lzo_extract/0-26496.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-block.file.lzo_extract/0-26496.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-block.stdin.lzo_extract/0-26485.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-block.stdin.lzo_extract/0-26485.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1e581e7c125348fc64d17318e5fd581337601d8cc5b25662f7d3af5b7d6e62a
+size 26485

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-block.stdin.lzo_extract/0-26485.lzo_extract/0-26485
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-block.stdin.lzo_extract/0-26485.lzo_extract/0-26485
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-file.lzo_extract/0-3929.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-file.lzo_extract/0-3929.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb9b72bb986845baa3322c3274e4ad87cb928d9cf475c07be2e8450f4ff35dc2
+size 3929

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-file.lzo_extract/0-3929.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-file.lzo_extract/0-3929.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-file.lzo_extract/3929-30425.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-file.lzo_extract/3929-30425.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63f5c6230c72f8383168c693dc521271536bcb9a9041fffd55c3880e79aded16
+size 26496

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-file.lzo_extract/3929-30425.lzo_extract/big256k.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.multi-file.lzo_extract/3929-30425.lzo_extract/big256k.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9b301f15e8d2b289f9f6192cda6399184a13076d463c49b249dfba6eab5a11
+size 265608

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.simple.file.lzo_extract/0-3929.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.simple.file.lzo_extract/0-3929.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:206c895a3ccd906487078fe288115d3896db7339653fa7052d9952c9a160d1fc
+size 3929

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.simple.file.lzo_extract/0-3929.lzo_extract/lorem.txt
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.simple.file.lzo_extract/0-3929.lzo_extract/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.simple.stdin.lzo_extract/0-3920.lzo
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.simple.stdin.lzo_extract/0-3920.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b81386ecfbdea5cd8299ac231259dd084333e1a6cd8899a403772228e1126db2
+size 3920

--- a/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.simple.stdin.lzo_extract/0-3920.lzo_extract/0-3920
+++ b/tests/integration/compression/lzo/__output__/lorem.crc32.no-checksum.no-filter.simple.stdin.lzo_extract/0-3920.lzo_extract/0-3920
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b095cfec3af2f64ddd11e013442a4a42932467da9175e3ea356adc82e57678e6
+size 6324


### PR DESCRIPTION
We did not handle cases where the uncompressed size of the data was over the default 256k block size. In those cases the content is compressed in multiple chunks, with each chunk having a special chunk header (similar to the previous size crc header) describing the given chunk. The last chunk has 0 as uncompressed size.

Checksums are also optional in chunk headers depending on the main header flags.