### PR TITLE
Add force overwrite extract dir option

### DIFF
--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from unblob.models import Handler, Handlers, ValidChunk
-from unblob.processing import ExtractionConfig, process_file
+from unblob.processing import ExtractionConfig, process_files
 
 _ZIP_CONTENT = b"good file"
 # replacing _ZIP_CONTENT with _DAMAGED_ZIP_CONTENT will result in CRC error at unpacking time
@@ -53,7 +53,7 @@ def test_remove_extracted_chunks(input_dir: Path, output_dir: Path):
         entropy_depth=0,
     )
 
-    all_reports = process_file(config, path=input_dir)
+    all_reports = process_files(config, input_dir)
     assert list(output_dir.glob("**/*.zip")) == []
     assert all_reports == [], f"Unexpected error reports: {all_reports}"
 
@@ -65,7 +65,7 @@ def test_keep_all_problematic_chunks(input_dir: Path, output_dir: Path):
         entropy_depth=0,
     )
 
-    all_reports = process_file(config, path=input_dir)
+    all_reports = process_files(config, input_dir)
     # damaged zip file should not be removed
     assert all_reports != [], "Unexpectedly no errors found!"
     assert list(output_dir.glob("**/*.zip"))
@@ -78,7 +78,7 @@ def test_keep_all_unknown_chunks(input_dir: Path, output_dir: Path):
         entropy_depth=0,
     )
 
-    all_reports = process_file(config, path=input_dir)
+    all_reports = process_files(config, input_dir)
     assert list(output_dir.glob("**/*.unknown"))
     assert all_reports == [], f"Unexpected error reports: {all_reports}"
 
@@ -105,6 +105,6 @@ def test_keep_chunks_with_null_extractor(input_dir: Path, output_dir: Path):
         entropy_depth=0,
         handlers=Handlers([tuple([_HandlerWithNullExtractor])]),
     )
-    all_reports = process_file(config, path=input_dir)
+    all_reports = process_files(config, input_dir)
     assert list(output_dir.glob("**/*.null"))
     assert all_reports == [], f"Unexpected error reports: {all_reports}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,11 +174,11 @@ def test_archive_success(
         / "regular"
         / "__input__/"
     )
-    process_file_mock = mock.MagicMock()
+    process_files_mock = mock.MagicMock()
     logger_config_mock = mock.MagicMock()
     new_params = params + ["--extract-dir", str(tmp_path), str(in_path)]
     with mock.patch.object(
-        unblob.cli, "process_file", process_file_mock
+        unblob.cli, "process_files", process_files_mock
     ), mock.patch.object(unblob.cli, "configure_logger", logger_config_mock):
         result = runner.invoke(unblob.cli.cli, new_params)
     assert result.exit_code == 0
@@ -192,49 +192,8 @@ def test_archive_success(
         process_num=expected_process_num,
         handlers=BUILTIN_HANDLERS,
     )
-    process_file_mock.assert_called_once_with(config, in_path)
+    process_files_mock.assert_called_once_with(config, in_path)
     logger_config_mock.assert_called_once_with(expected_verbosity, tmp_path)
-
-
-def test_archive_multiple_files(tmp_path: Path):
-    runner = CliRunner()
-    in_path_1 = (
-        Path(__file__).parent
-        / "integration"
-        / "archive"
-        / "zip"
-        / "regular"
-        / "__input__/"
-    )
-    in_path_2 = (
-        Path(__file__).parent
-        / "integration"
-        / "archive"
-        / "rar"
-        / "default"
-        / "__input__/"
-    )
-    process_file_mock = mock.MagicMock()
-    with mock.patch.object(unblob.cli, "process_file", process_file_mock):
-        result = runner.invoke(
-            unblob.cli.cli,
-            ["--extract-dir", str(tmp_path), str(in_path_1), str(in_path_2)],
-        )
-    assert result.exit_code == 0
-    assert process_file_mock.call_count == 2
-    config = ExtractionConfig(
-        extract_root=tmp_path,
-        max_depth=DEFAULT_DEPTH,
-        entropy_depth=1,
-        entropy_plot=False,
-        process_num=DEFAULT_PROCESS_NUM,
-        keep_extracted_chunks=False,
-        handlers=mock.ANY,
-    )
-    assert process_file_mock.call_args_list == [
-        mock.call(config, in_path_1),
-        mock.call(config, in_path_2),
-    ]
 
 
 @pytest.mark.parametrize(
@@ -259,13 +218,13 @@ def test_keep_extracted_chunks(
     )
     params = args + ["--extract-dir", str(tmp_path), str(in_path)]
 
-    process_file_mock = mock.MagicMock()
-    with mock.patch.object(unblob.cli, "process_file", process_file_mock):
+    process_files_mock = mock.MagicMock()
+    with mock.patch.object(unblob.cli, "process_files", process_files_mock):
         result = runner.invoke(unblob.cli.cli, params)
 
     assert result.exit_code == 0
-    process_file_mock.assert_called_once()
+    process_files_mock.assert_called_once()
     assert (
-        process_file_mock.call_args.args[0].keep_extracted_chunks
+        process_files_mock.call_args.args[0].keep_extracted_chunks
         == keep_extracted_chunks
     ), fail_message

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -15,7 +15,7 @@ import pytest
 
 from unblob import handlers
 from unblob.models import Handler
-from unblob.processing import ExtractionConfig, process_file
+from unblob.processing import ExtractionConfig, process_files
 from unblob.testing import (
     check_output_is_the_same,
     check_reports,
@@ -35,7 +35,7 @@ def test_all_handlers(input_dir: Path, output_dir: Path, tmp_path: Path):
         entropy_depth=0,
         keep_extracted_chunks=True,
     )
-    all_reports = process_file(config, path=input_dir)
+    all_reports = process_files(config, input_dir)
 
     check_output_is_the_same(output_dir, tmp_path)
     check_reports(all_reports)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -5,10 +5,13 @@ import pytest
 
 from unblob.models import UnknownChunk, ValidChunk
 from unblob.processing import (
+    ExtractionConfig,
     calculate_buffer_size,
     calculate_entropy,
     calculate_unknown_chunks,
     draw_entropy_plot,
+    get_existing_extract_dirs,
+    get_extract_dir_for_input,
     remove_inner_chunks,
 )
 
@@ -141,3 +144,44 @@ def test_draw_entropy_plot_no_exception(percentages: List[float]):
 )
 def test_calculate_entropy_no_exception(path: Path, draw_plot: bool):
     assert calculate_entropy(path, draw_plot=draw_plot) is None
+
+
+@pytest.mark.parametrize(
+    "root, path, extract_dir_prefix",
+    [
+        (".", "firmware", "firmware"),
+        ("root", "root/firmware", "firmware"),
+        ("root/dir", "root/dir/firmware", "firmware"),
+        ("root", "/some/place/else/firmware", "firmware"),
+    ],
+)
+def test_get_extract_dir_for_input(
+    root: str, path: str, extract_dir_prefix: str, tmp_path: Path
+):
+    cfg = ExtractionConfig(extract_root=tmp_path, entropy_depth=0)
+    assert get_extract_dir_for_input(cfg, Path(root), Path(path)) == (
+        tmp_path / Path(extract_dir_prefix + cfg.extract_suffix)
+    )
+
+
+def test_existing_extract_dirs_can_be_found(tmp_path: Path):
+    cfg = ExtractionConfig(extract_root=tmp_path, entropy_depth=0)
+
+    already_extracted_files = [
+        Path("have_been_extracted"),
+        Path("some_directory") / "also_have_been_extacted",
+    ]
+    existing_extract_dirs = [
+        tmp_path / (e.name + cfg.extract_suffix) for e in already_extracted_files
+    ]
+
+    for e in existing_extract_dirs:
+        e.mkdir()
+
+    to_be_extracted_files = [
+        Path("yet_to_extract"),
+        Path("some_other_directory") / "also_yet_to_extract",
+    ]
+    files_to_extract = already_extracted_files + to_be_extracted_files
+
+    assert get_existing_extract_dirs(cfg, files_to_extract) == existing_extract_dirs

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -147,20 +147,21 @@ def test_calculate_entropy_no_exception(path: Path, draw_plot: bool):
 
 
 @pytest.mark.parametrize(
-    "root, path, extract_dir_prefix",
+    "extract_root, path, extract_dir_prefix",
     [
-        (".", "firmware", "firmware"),
-        ("root", "root/firmware", "firmware"),
-        ("root/dir", "root/dir/firmware", "firmware"),
-        ("root", "/some/place/else/firmware", "firmware"),
+        ("/extract", "firmware", "firmware"),
+        ("/extract", "relative/firmware", "firmware"),
+        ("/extract", "/extract/dir/firmware", "dir/firmware"),
+        ("/extract/dir", "/extract/dir/firmware", "firmware"),
+        ("/extract", "/some/place/else/firmware", "firmware"),
     ],
 )
 def test_get_extract_dir_for_input(
-    root: str, path: str, extract_dir_prefix: str, tmp_path: Path
+    extract_root: str, path: str, extract_dir_prefix: str
 ):
-    cfg = ExtractionConfig(extract_root=tmp_path, entropy_depth=0)
-    assert get_extract_dir_for_input(cfg, Path(root), Path(path)) == (
-        tmp_path / Path(extract_dir_prefix + cfg.extract_suffix)
+    cfg = ExtractionConfig(extract_root=Path(extract_root), entropy_depth=0)
+    assert get_extract_dir_for_input(cfg, Path(path)) == (
+        cfg.extract_root / Path(extract_dir_prefix + cfg.extract_suffix)
     )
 
 

--- a/unblob/cli.py
+++ b/unblob/cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, List, Optional
 
 import click
 from structlog import get_logger
@@ -153,7 +153,7 @@ class UnblobContext(click.Context):
     expose_value=False,
 )
 def cli(
-    files: Tuple[Path],
+    files: List[Path],
     extract_root: Path,
     depth: int,
     entropy_depth: int,

--- a/unblob/cli.py
+++ b/unblob/cli.py
@@ -18,7 +18,7 @@ from .processing import (
     DEFAULT_PROCESS_NUM,
     DEFAULT_SKIP_MAGIC,
     ExtractionConfig,
-    process_file,
+    process_files,
 )
 
 logger = get_logger()
@@ -183,10 +183,7 @@ def cli(
     )
 
     logger.info("Start processing files", count=noformat(len(files)))
-    all_reports = []
-    for path in files:
-        report = process_file(config, path)
-        all_reports.extend(report)
+    all_reports = process_files(config, *files)
     return all_reports
 
 

--- a/unblob/cli.py
+++ b/unblob/cli.py
@@ -91,6 +91,13 @@ class UnblobContext(click.Context):
     help="Extract the files to this directory. Will be created if doesn't exist.",
 )
 @click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    show_default=True,
+    help="Force extraction removing previously extracted files.",
+)
+@click.option(
     "-d",
     "--depth",
     default=DEFAULT_DEPTH,
@@ -155,6 +162,7 @@ class UnblobContext(click.Context):
 def cli(
     files: List[Path],
     extract_root: Path,
+    force: bool,
     depth: int,
     entropy_depth: int,
     skip_magic: Iterable[str],
@@ -173,6 +181,7 @@ def cli(
 
     config = ExtractionConfig(
         extract_root=extract_root,
+        force_extract=force,
         max_depth=depth,
         entropy_depth=entropy_depth,
         entropy_plot=bool(verbose >= 3),

--- a/unblob/models.py
+++ b/unblob/models.py
@@ -20,7 +20,6 @@ logger = get_logger()
 
 @attr.define
 class Task:
-    root: Path
     path: Path
     depth: int
 

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -75,7 +75,7 @@ def get_existing_extract_dirs(
         else:
             subpaths = [path]
         for path in subpaths:
-            d = get_extract_dir_for_input(config, root, path)
+            d = get_extract_dir_for_input(config, path)
             if d.exists():
                 extract_dirs.append(d)
 
@@ -83,9 +83,7 @@ def get_existing_extract_dirs(
 
 
 def _process_one_file(config: ExtractionConfig, path: Path) -> List[Report]:
-    root = path if path.is_dir() else path.parent
     root_task = Task(
-        root=root,
         path=path,
         depth=0,
     )
@@ -147,7 +145,6 @@ class Processor:
             for path in task.path.iterdir():
                 result.add_new_task(
                     Task(
-                        root=task.root,
                         path=path,
                         depth=task.depth,
                     )
@@ -191,9 +188,7 @@ class _FileTask:
         self.size = size
         self.result = result
 
-        self.extract_dir = get_extract_dir_for_input(
-            config, self.task.root, self.task.path
-        )
+        self.extract_dir = get_extract_dir_for_input(config, self.task.path)
 
     def process(self):
         logger.debug("Processing file", path=self.task.path, size=self.size)
@@ -269,14 +264,13 @@ class _FileTask:
         if outdir.exists():
             self.result.add_new_task(
                 Task(
-                    root=self.config.extract_root,
                     path=outdir,
                     depth=self.task.depth + 1,
                 )
             )
 
 
-def get_extract_dir_for_input(config: ExtractionConfig, root: Path, path: Path) -> Path:
+def get_extract_dir_for_input(config: ExtractionConfig, path: Path) -> Path:
     """Extraction dir under root with the name of path."""
     try:
         relative_path = path.relative_to(config.extract_root)

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -44,8 +44,20 @@ class ExtractionConfig:
 
 
 @terminate_gracefully
-def process_file(config: ExtractionConfig, path: Path) -> List[Report]:
+def process_files(config: ExtractionConfig, *paths: Path) -> List[Report]:
+    all_reports = []
+    for path in paths:
+        report = _process_one_file(config, path)
+        all_reports.extend(report)
 
+    return all_reports
+
+
+def process_file(config: ExtractionConfig, path: Path) -> List[Report]:
+    return process_files(config, path)
+
+
+def _process_one_file(config: ExtractionConfig, path: Path) -> List[Report]:
     root = path if path.is_dir() else path.parent
     root_task = Task(
         root=root,

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import shutil
 import stat
 import statistics
 from operator import attrgetter
@@ -20,7 +21,7 @@ from .logging import noformat
 from .math import shannon_entropy
 from .models import ExtractError, Task, TaskResult, UnknownChunk, ValidChunk
 from .pool import make_pool
-from .report import Report, UnknownError
+from .report import ExtractDirectoriesExistReport, Report, UnknownError
 from .signals import terminate_gracefully
 
 logger = get_logger()
@@ -33,6 +34,7 @@ DEFAULT_SKIP_MAGIC = ("ELF", "JPEG", "GIF", "PNG")
 @attr.define(kw_only=True)
 class ExtractionConfig:
     extract_root: Path
+    force_extract: bool = False
     entropy_depth: int
     entropy_plot: bool = False
     max_depth: int = DEFAULT_DEPTH
@@ -45,6 +47,16 @@ class ExtractionConfig:
 
 @terminate_gracefully
 def process_files(config: ExtractionConfig, *paths: Path) -> List[Report]:
+    existing_extract_dirs = get_existing_extract_dirs(config, paths)
+
+    if config.force_extract:
+        for d in existing_extract_dirs:
+            shutil.rmtree(d)
+    elif existing_extract_dirs:
+        report = ExtractDirectoriesExistReport(paths=existing_extract_dirs)
+        logger.error("Extraction directories already exist", **report.asdict())
+        return [report]
+
     all_reports = []
     for path in paths:
         report = _process_one_file(config, path)
@@ -53,8 +65,21 @@ def process_files(config: ExtractionConfig, *paths: Path) -> List[Report]:
     return all_reports
 
 
-def process_file(config: ExtractionConfig, path: Path) -> List[Report]:
-    return process_files(config, path)
+def get_existing_extract_dirs(
+    config: ExtractionConfig, paths: Iterable[Path]
+) -> List[Path]:
+    extract_dirs = []
+    for path in paths:
+        if path.is_dir():
+            subpaths = path.iterdir()
+        else:
+            subpaths = [path]
+        for path in subpaths:
+            d = get_extract_dir_for_input(config, root, path)
+            if d.exists():
+                extract_dirs.append(d)
+
+    return extract_dirs
 
 
 def _process_one_file(config: ExtractionConfig, path: Path) -> List[Report]:
@@ -166,14 +191,9 @@ class _FileTask:
         self.size = size
         self.result = result
 
-        self.extract_dir = self._get_extract_dir()
-
-    def _get_extract_dir(self) -> Path:
-        """Extraction dir under root with the name of path."""
-        relative_path = self.task.path.relative_to(self.task.root)
-        extract_name = relative_path.name + self.config.extract_suffix
-        extract_dir = self.config.extract_root / relative_path.with_name(extract_name)
-        return extract_dir.expanduser().resolve()
+        self.extract_dir = get_extract_dir_for_input(
+            config, self.task.root, self.task.path
+        )
 
     def process(self):
         logger.debug("Processing file", path=self.task.path, size=self.size)
@@ -254,6 +274,14 @@ class _FileTask:
                     depth=self.task.depth + 1,
                 )
             )
+
+
+def get_extract_dir_for_input(config: ExtractionConfig, root: Path, path: Path) -> Path:
+    """Extraction dir under root with the name of path."""
+    relative_path = path.relative_to(root)
+    extract_name = relative_path.name + config.extract_suffix
+    extract_dir = config.extract_root / relative_path.with_name(extract_name)
+    return extract_dir.expanduser().resolve()
 
 
 def remove_inner_chunks(chunks: List[ValidChunk]) -> List[ValidChunk]:

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -278,8 +278,12 @@ class _FileTask:
 
 def get_extract_dir_for_input(config: ExtractionConfig, root: Path, path: Path) -> Path:
     """Extraction dir under root with the name of path."""
-    relative_path = path.relative_to(root)
-    extract_name = relative_path.name + config.extract_suffix
+    try:
+        relative_path = path.relative_to(config.extract_root)
+    except ValueError:
+        # path is not inside root, i.e. it is an input file
+        relative_path = Path(path.name)
+    extract_name = path.name + config.extract_suffix
     extract_dir = config.extract_root / relative_path.with_name(extract_name)
     return extract_dir.expanduser().resolve()
 

--- a/unblob/report.py
+++ b/unblob/report.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from pathlib import Path
 from typing import List, Optional
 
 import attr
@@ -48,6 +49,12 @@ class ExtractCommandFailedReport(Report):
     stdout: bytes
     stderr: bytes
     exit_code: int
+
+
+@attr.define(kw_only=True)
+class ExtractDirectoriesExistReport(Report):
+    severity: Severity = Severity.ERROR
+    paths: List[Path]
 
 
 @attr.define(kw_only=True)


### PR DESCRIPTION
With this config, if the extraction dir exist, it will automatically
deleted before the processing, thus overridden with the new results.