### PR TITLE
pytest: do not collect tests from known non-test paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,15 @@ unblob = "unblob.cli:main"
 
 [tool.pytest.ini_options]
 addopts = "--cov=unblob --cov=tests --cov-branch --cov-fail-under=90"
+norecursedirs = """
+  *.egg
+  *_extract
+  .*
+  dist
+  build
+  target
+  tests/integration
+"""
 
 [tool.vulture]
 paths = ["unblob/" ]


### PR DESCRIPTION
Inspiration is taken from .gitignore. See the following URL for
details:
  https://docs.pytest.org/en/latest/example/pythoncollection.html?highlight=discovery#changing-directory-recursion