### PR TITLE
Stop emitting a ValidChunk for every bzip2 stream.

### DIFF
--- a/tests/integration/compression/bzip2/__input__/collated.bzip2
+++ b/tests/integration/compression/bzip2/__input__/collated.bzip2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:882c591e5eddf406213eea5b0235ea08e8e73e0507d3491f453f3c286c17de65
+size 5090

--- a/tests/integration/compression/bzip2/__input__/collated.headpad.bzip2
+++ b/tests/integration/compression/bzip2/__input__/collated.headpad.bzip2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f320bd0a2dd87b00d9ba78a778747c4094fbfa6aaff108d061ddd00074fa8b9
+size 5107

--- a/tests/integration/compression/bzip2/__output__/collated.bzip2_extract/collated
+++ b/tests/integration/compression/bzip2/__output__/collated.bzip2_extract/collated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9cf7bd4ef02c7212aa39488e14a78b16fef6acf91a3b2351c84f3094ced2c7f
+size 13120

--- a/tests/integration/compression/bzip2/__output__/collated.headpad.bzip2_extract/0-17.unknown
+++ b/tests/integration/compression/bzip2/__output__/collated.headpad.bzip2_extract/0-17.unknown
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:444074d5328d52b4e0036d37b1b6ea0a9fe3b0c96872d1157fbf01b6fdb2ce8d
+size 17

--- a/tests/integration/compression/bzip2/__output__/collated.headpad.bzip2_extract/17-5107.bzip2
+++ b/tests/integration/compression/bzip2/__output__/collated.headpad.bzip2_extract/17-5107.bzip2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:882c591e5eddf406213eea5b0235ea08e8e73e0507d3491f453f3c286c17de65
+size 5090

--- a/tests/integration/compression/bzip2/__output__/collated.headpad.bzip2_extract/17-5107.bzip2_extract/17-5107
+++ b/tests/integration/compression/bzip2/__output__/collated.headpad.bzip2_extract/17-5107.bzip2_extract/17-5107
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9cf7bd4ef02c7212aa39488e14a78b16fef6acf91a3b2351c84f3094ced2c7f
+size 13120


### PR DESCRIPTION
Regardless of what is in concatenated bzip streams, we should unpack it into a single file. Unblob will pickup the chunks anyway when parsing the output of bzip decompression. It's faster and more efficient.

Fix #316 