### PR TITLE
Do not extract posix/pax tar file and global headers

### DIFF
--- a/tests/integration/archive/tar/__input__/cherry.posixly_correct.tar
+++ b/tests/integration/archive/tar/__input__/cherry.posixly_correct.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:295c6d4cd2bb5aeaaa32e27a5d63e5900a8ef764aee91cf85ba5c578826b3378
+size 20480

--- a/tests/integration/archive/tar/__output__/cherry.posixly_correct.tar_extract/cherry1.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posixly_correct.tar_extract/cherry1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7592083f2355ad7e207557efabb3594bf62c9e39677298e8265766a37d835c39
+size 8

--- a/tests/integration/archive/tar/__output__/cherry.posixly_correct.tar_extract/cherry2.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posixly_correct.tar_extract/cherry2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb6f92894363eceff37d58287d2b8b37bb17a00b320312ed59924a8ec07004a6
+size 8

--- a/tests/integration/archive/tar/__output__/cherry.posixly_correct.tar_extract/cherry3.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posixly_correct.tar_extract/cherry3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4d09282b5ac47cc58aa5dc4fe3e8d6829ac737adfe49ee32efee9cf4bf6cdf3
+size 8

--- a/tests/integration/archive/tar/__output__/cherry.posixly_correct.tar_extract/cherry4.txt
+++ b/tests/integration/archive/tar/__output__/cherry.posixly_correct.tar_extract/cherry4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7843a44cca6d57497113ed505d027b9f5ffac78f1de7809f81ae9b314d943e79
+size 8

--- a/unblob/handlers/archive/tar.py
+++ b/unblob/handlers/archive/tar.py
@@ -102,7 +102,9 @@ class TarHandler(StructHandler):
     """
     HEADER_STRUCT = "posix_header_t"
 
-    EXTRACTOR = Command("7z", "x", "-xr!PaxHeaders", "-y", "{inpath}", "-o{outdir}")
+    EXTRACTOR = Command(
+        "7z", "x", "-xr!PaxHeaders*", "-xr!GlobalHead*", "-y", "{inpath}", "-o{outdir}"
+    )
 
     def calculate_chunk(
         self, file: io.BufferedIOBase, start_offset: int


### PR DESCRIPTION
posix or pax tar file can contain extra headers to hold global and per-file
key-value pairs. In posixly correct way the file-header is named 'PaxHeaders.%p'
while the global header is named: $TMPDIR/GlobalHead.%p.%n

No posixly correct way the file-header is simply 'PaxHeaders'

Unfortunatelly the user can use a custom name for both by specifying
-o exthdr.name= or -o globexthdr.name= settings, though we have no way
to detect such cases, so at least we aim for handling the default names.

More details:
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html#tag_20_92_13_02


Test file can be generated with posixly correct headers:

POSIXLY_CORRECT=1 tar -H posix \
	--atime-preserve \
	--xattrs --acls \
	--selinux \
	--pax-option testkey=test \ # <- this will be included in the global header
	-cf cherry.posixly_correct.tar .