### PR TITLE
Nix: force unblob to use an existing locale from the nix closure

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,7 @@
 , makeWrapper
 , mkPoetryApp
 , poetry2nix
+, glibc
 , python3
 , rustPlatform
 , e2fsprogs
@@ -67,7 +68,9 @@ let
     python = python3;
 
     postFixup = ''
-      wrapProgram $out/bin/unblob --prefix PATH : ${lib.makeBinPath runtimeDeps}
+      wrapProgram $out/bin/unblob --prefix PATH : ${lib.makeBinPath runtimeDeps} \
+                                  --set LOCALE_ARCHIVE_2_27 ${glibc}/lib/locale/locale-archive \
+                                  --set LC_ALL C.UTF-8
     '';
 
     UNBLOB_BUILD_RUST_EXTENSION = "1";


### PR DESCRIPTION
Locale settings are environment dependent and Nix is happy to pick-up
global settings and work well as long as the glibc available in the
global environment uses compatible locale-archive format. However on
older systems it may not be the case and applications fall back to a
non-UTF-8 `C` locale, causing encoding issues in at least p7zip and
possible in other locations as well.

The `LOCALE_ARCHIVE_2_27` flag is specific [1] to the glibc used by
Nix, so if an external non-Nix based application is called, it will be
ignored and will fall back to the locale-archive available on the
system.

---

1: https://github.com/NixOS/nixpkgs/blob/d861c9c7e6051649a2a85f6666e1ce9e389302bb/pkgs/development/libraries/glibc/nix-locale-archive.patch