### PR TITLE
Cpio padding fix

### DIFF
--- a/tests/integration/archive/cpio/cpio_binary/__input__/test.bin.cpio
+++ b/tests/integration/archive/cpio/cpio_binary/__input__/test.bin.cpio
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a4b7d41131e0ef339da852e1439f36743ad14e01c93b91cde2985f2b9b04243
+size 1024

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test0
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test00
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test00
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test000
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test0000
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test0000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test0001
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test0001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test0002
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test0002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test0003
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test0003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test001
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test002
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test003
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test01
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test01
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test02
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test02
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test03
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test03
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test1
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test2
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test3
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio_extract/test3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__input__/test.newc.cpio
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__input__/test.newc.cpio
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b26186f6279ec9bf1f9a684a3ca6600eb45a1bf3222f22b658a4b95520074eed
+size 2560

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test0
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test00
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test00
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test000
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test0000
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test0000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test0001
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test0001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test0002
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test0002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test0003
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test0003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test001
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test002
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test003
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test01
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test01
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test02
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test02
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test03
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test03
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test1
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test2
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test3
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio_extract/test3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__input__/test.crc.cpio
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__input__/test.crc.cpio
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:525035c504b13c9f5193755f9be9010ff17f1544419a77cb5e0cdebad7fe8236
+size 2560

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test0
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test00
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test00
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test000
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test0000
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test0000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test0001
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test0001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test0002
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test0002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test0003
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test0003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test001
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test002
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test003
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test01
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test01
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test02
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test02
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test03
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test03
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test1
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test2
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test3
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio_extract/test3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__input__/test.odc.cpio
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__input__/test.odc.cpio
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c463cc8d4ec32fdf3975bab88e0c6993628d562825c7bbbf00f523c28db24d52
+size 1536

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test0
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test00
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test00
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test000
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test0000
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test0000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test0001
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test0001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test0002
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test0002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test0003
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test0003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test001
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test002
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test003
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test01
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test01
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test02
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test02
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test03
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test03
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test1
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test2
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test3
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio_extract/test3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/unblob/handlers/archive/cpio.py
+++ b/unblob/handlers/archive/cpio.py
@@ -114,8 +114,8 @@ class _CPIOHandlerBase(StructHandler):
     @classmethod
     def _pad_content(cls, header, c_filesize: int, c_namesize: int) -> int:
         """Pad header and content with _PAD_ALIGN bytes."""
-        padded_header = round_up(len(header), cls._PAD_ALIGN)
-        padded_content = round_up(c_filesize + c_namesize, cls._PAD_ALIGN)
+        padded_header = round_up(len(header) + c_namesize, cls._PAD_ALIGN)
+        padded_content = round_up(c_filesize, cls._PAD_ALIGN)
         return padded_header + padded_content
 
     @staticmethod
@@ -202,7 +202,7 @@ class PortableOldASCIIHandler(_CPIOHandlerBase):
     """
     HEADER_STRUCT = "old_ascii_header_t"
 
-    _PAD_ALIGN = 2
+    _PAD_ALIGN = 1
 
     @staticmethod
     def _calculate_file_size(header) -> int:


### PR DESCRIPTION
    There are two paddings in CPIO: one for the header + name and an other for
    the filesize. We calculated one for the header and one for name + filesize
    which is incorrect, though worked in some cases when things aligned well.
    
    Old ascii format uses no padding (paddig=1) instead of 2 bytes.
