### PR TITLE
Fix bzip2 compressed magic handling & use hyperscan instead of iterbits to search for end of stream magic

### DIFF
--- a/tests/handlers/compression/test_bzip2.py
+++ b/tests/handlers/compression/test_bzip2.py
@@ -3,8 +3,17 @@ import pytest
 from unblob.file_utils import File, InvalidInputFormat
 from unblob.handlers.compression.bzip2 import BZip2Handler
 
-BLOCK_HEADER = b"\x31\x41\x59\x26\x53\x59"
-BLOCK_ENDMARK = b"\x17\x72\x45\x38\x50\x90"
+STREAM_MAGIC = b"BZ"
+STREAM_HEADER = STREAM_MAGIC + b"h1"
+FAKE_CRC = b"\xde\xad\xbe\xef"
+BLOCK_START_MAGIC = b"\x31\x41\x59\x26\x53\x59"
+BLOCK_SORT_BYTE = b"\x00"
+BLOCK_HEADER = BLOCK_START_MAGIC + FAKE_CRC + BLOCK_SORT_BYTE
+STREAM_END_MAGIC = b"\x17\x72\x45\x38\x50\x90"
+STREAM_FOOTER = STREAM_END_MAGIC + FAKE_CRC
+CONTENT = b"123"
+
+STREAM_SIZE = len(STREAM_HEADER + BLOCK_HEADER + STREAM_FOOTER)
 
 
 def shift_left(value: bytes, bits: int) -> bytes:
@@ -14,116 +23,188 @@ def shift_left(value: bytes, bits: int) -> bytes:
 
 
 @pytest.mark.parametrize(
-    "content, start_offset, expected_end_offset",
+    "content, start_offset, expected_length",
     (
         pytest.param(
-            BLOCK_HEADER + b"123" + BLOCK_ENDMARK, 0, 15, id="aligned_to_zero"
+            STREAM_HEADER + BLOCK_HEADER + CONTENT + STREAM_FOOTER,
+            0,
+            STREAM_SIZE + 3,
+            id="aligned_to_zero",
         ),
         pytest.param(
-            b"0123" + BLOCK_HEADER + b"456" + BLOCK_ENDMARK,
+            b"0123" + STREAM_HEADER + BLOCK_HEADER + CONTENT + STREAM_FOOTER,
             4,
-            19,
+            STREAM_SIZE + 3,
             id="aligned_with_offset",
         ),
         pytest.param(
-            b"0123" + BLOCK_HEADER + BLOCK_ENDMARK,
+            b"0123" + STREAM_HEADER + BLOCK_HEADER + STREAM_FOOTER,
             4,
-            16,
+            STREAM_SIZE,
             id="aligned_offset_empty_content",
         ),
-        # extra byte when shifted
         pytest.param(
-            shift_left(BLOCK_HEADER, 1) + b"123" + BLOCK_ENDMARK,
-            0,
-            16,
-            id="block_header_left_shifted_by_1",
-        ),
-        pytest.param(
-            shift_left(BLOCK_HEADER, 7) + b"123" + BLOCK_ENDMARK,
-            0,
-            16,
-            id="block_header_left_shifted_by_7",
-        ),
-        pytest.param(
-            BLOCK_HEADER + b"123" + shift_left(BLOCK_ENDMARK, 1),
-            0,
-            16,
-            id="block_endmark_left_shifted_by_1",
-        ),
-        pytest.param(
-            BLOCK_HEADER + b"123" + shift_left(BLOCK_ENDMARK, 7),
-            0,
-            16,
-            id="block_endmark_left_shifted_by_7",
-        ),
-        pytest.param(
-            shift_left(BLOCK_HEADER, 1) + b"123" + shift_left(BLOCK_ENDMARK, 1),
-            0,
-            17,
-            id="both_marks_shifted_by_1",
-        ),
-        pytest.param(
-            shift_left(BLOCK_HEADER, 7) + b"123" + shift_left(BLOCK_ENDMARK, 7),
-            0,
-            17,
-            id="both_marks_shifted_by_7",
-        ),
-        pytest.param(
-            BLOCK_HEADER
-            + b"123"
-            + BLOCK_ENDMARK
-            + b"AAAA"
+            STREAM_HEADER
             + BLOCK_HEADER
-            + b"123"
-            + BLOCK_ENDMARK,
+            + CONTENT
+            + shift_left(STREAM_END_MAGIC, 1)
+            + FAKE_CRC,
             0,
-            15,
+            STREAM_SIZE + 1 + 3,
+            id="block_end_magic_left_shifted_by_1",
+        ),
+        pytest.param(
+            STREAM_HEADER
+            + BLOCK_HEADER
+            + CONTENT
+            + shift_left(STREAM_END_MAGIC, 7)
+            + FAKE_CRC,
+            0,
+            STREAM_SIZE + 1 + 3,
+            id="block_end_magic_left_shifted_by_7",
+        ),
+        pytest.param(
+            STREAM_HEADER
+            + BLOCK_HEADER
+            + CONTENT
+            + STREAM_FOOTER
+            + b"AAAA"
+            + STREAM_HEADER
+            + BLOCK_HEADER
+            + CONTENT
+            + STREAM_FOOTER,
+            0,
+            STREAM_SIZE + 3,
             id="two_bzip2_streams_separated_by_garbage_1",
         ),
         pytest.param(
-            BLOCK_HEADER
-            + b"123"
-            + BLOCK_ENDMARK
+            STREAM_HEADER
             + BLOCK_HEADER
-            + b"123"
-            + BLOCK_ENDMARK,
+            + CONTENT
+            + STREAM_FOOTER
+            + STREAM_HEADER
+            + BLOCK_HEADER
+            + CONTENT
+            + STREAM_FOOTER,
             0,
-            30,
+            (STREAM_SIZE + 3) * 2,
             id="two_bzip2_streams",
         ),
         pytest.param(
-            BLOCK_HEADER
-            + b"123"
-            + BLOCK_ENDMARK
+            STREAM_HEADER
             + BLOCK_HEADER
-            + b"123"
-            + BLOCK_ENDMARK
+            + CONTENT
+            + STREAM_FOOTER
+            + STREAM_HEADER
+            + BLOCK_HEADER
+            + CONTENT
+            + STREAM_FOOTER
             + b"AAAA",
             0,
-            30,
+            (STREAM_SIZE + 3) * 2,
             id="two_bzip2_streams_followed_by_garbage_2",
+        ),
+        pytest.param(
+            STREAM_HEADER + BLOCK_HEADER + CONTENT + STREAM_FOOTER + STREAM_MAGIC,
+            0,
+            STREAM_SIZE + 3,
+            id="just_stream_magic_after_stream",
+        ),
+        pytest.param(
+            STREAM_HEADER
+            + BLOCK_HEADER
+            + CONTENT
+            + STREAM_FOOTER
+            + STREAM_HEADER
+            + BLOCK_HEADER
+            + CONTENT,
+            0,
+            STREAM_SIZE + 3,
+            id="missing_footer_after_stream",
+        ),
+        pytest.param(
+            STREAM_HEADER
+            + BLOCK_HEADER
+            + CONTENT
+            + STREAM_FOOTER
+            + STREAM_HEADER
+            + CONTENT
+            + STREAM_FOOTER,
+            0,
+            STREAM_SIZE + 3,
+            id="missing_block_header_after_stream",
+        ),
+        pytest.param(
+            STREAM_HEADER + BLOCK_HEADER + CONTENT + STREAM_FOOTER + b"AAAA",
+            0,
+            STREAM_SIZE + 3,
+            id="garbage_after_stream_footer",
+        ),
+        pytest.param(
+            STREAM_END_MAGIC + STREAM_HEADER + BLOCK_HEADER + CONTENT + STREAM_FOOTER,
+            len(STREAM_END_MAGIC),
+            STREAM_SIZE + 3,
+            id="stream_end_magic_before_start",
+        ),
+        pytest.param(
+            STREAM_END_MAGIC
+            + b"AAAA"
+            + STREAM_HEADER
+            + BLOCK_HEADER
+            + CONTENT
+            + STREAM_FOOTER,
+            len(STREAM_END_MAGIC) + 4,
+            STREAM_SIZE + 3,
+            id="stream_end_magic_before_start_and_padding",
+        ),
+        pytest.param(
+            STREAM_HEADER
+            + BLOCK_HEADER
+            + CONTENT
+            + STREAM_FOOTER
+            + STREAM_HEADER
+            + BLOCK_START_MAGIC,
+            0,
+            STREAM_SIZE + 3,
+            id="just_block_magic_after_footer",
+        ),
+        pytest.param(
+            STREAM_HEADER + BLOCK_HEADER + CONTENT + STREAM_FOOTER + STREAM_HEADER,
+            0,
+            STREAM_SIZE + 3,
+            id="just_stream_header_after_footer",
         ),
     ),
 )
-def test_bzip2_recover(content: bytes, start_offset: int, expected_end_offset: int):
+def test_bzip2_recover(content: bytes, start_offset: int, expected_length: int):
     handler = BZip2Handler()
     fake_file = File.from_bytes(content)
-    end_offset = handler.bzip2_recover(fake_file, start_offset)
-    assert end_offset == expected_end_offset
+    fake_file.seek(start_offset)
+    chunk = handler.calculate_chunk(fake_file, start_offset)
+    assert chunk is not None
+    assert chunk.end_offset == start_offset + expected_length
 
 
 @pytest.mark.parametrize(
     "content",
     (
-        pytest.param(b"123", id="shorter_than_block"),
-        pytest.param(b"asdfasdf", id="not_found"),
-        pytest.param(b"0123" + BLOCK_HEADER, id="no_block_endmark"),
-        pytest.param(b"0123" + BLOCK_ENDMARK, id="no_block_header"),
-        # undefined behavior: (BLOCK_ENDMARK + BLOCK_HEADER),
+        pytest.param(STREAM_HEADER, id="just_stream_header"),
+        pytest.param(STREAM_HEADER + CONTENT, id="missing_block_header"),
+        pytest.param(
+            STREAM_HEADER + CONTENT + STREAM_FOOTER, id="missing_block_header2"
+        ),
+        pytest.param(STREAM_HEADER + BLOCK_START_MAGIC, id="only_block_start_magic"),
+        pytest.param(
+            STREAM_HEADER + BLOCK_HEADER + CONTENT, id="missing_stream_footer"
+        ),
+        pytest.param(
+            STREAM_HEADER + BLOCK_HEADER + CONTENT + STREAM_END_MAGIC,
+            id="incomplete_stream_footer",
+        ),
     ),
 )
 def test_bzip2_recover_error(content: bytes):
     handler = BZip2Handler()
     fake_file = File.from_bytes(content)
     with pytest.raises(InvalidInputFormat):
-        handler.bzip2_recover(fake_file, 0)
+        handler.calculate_chunk(fake_file, 0)

--- a/tests/integration/compression/bzip2/__input__/multiblock.bzip2
+++ b/tests/integration/compression/bzip2/__input__/multiblock.bzip2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf56e4b474efcc08f4d4f1697438cf2e8ca0c651bd67b80373a97e803a0f438d
+size 17339

--- a/tests/integration/compression/bzip2/__output__/multiblock.bzip2_extract/multiblock
+++ b/tests/integration/compression/bzip2/__output__/multiblock.bzip2_extract/multiblock
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c3160a551947fbdf9092febca0d5dca1215e20ce36d27f152790d3e25fa0823
+size 100329

--- a/unblob/handlers/compression/bzip2.py
+++ b/unblob/handlers/compression/bzip2.py
@@ -14,7 +14,7 @@ logger = get_logger()
 BLOCK_HEADER = 0x0000_3141_5926_5359
 BLOCK_ENDMARK = 0x0000_1772_4538_5090
 # BCD-encoded digits of BLOCK_HEADER
-COMPRESSED_MAGIC = b"1AY&SY\x86\xc6"
+COMPRESSED_MAGIC = b"1AY&SY"
 COMPRESSED_MAGIC_LENGTH = 6 * 8
 
 BLOCK_ENDMARK_SHIFTED = BLOCK_ENDMARK << COMPRESSED_MAGIC_LENGTH
@@ -32,10 +32,13 @@ class BZip2Handler(StructHandler):
 
     C_DEFINITIONS = r"""
         typedef struct bzip2_header {
+            // stream header
             char magic[2];              // 'BZ' signature/magic number
             uint8 version;              // 'h' for Bzip2 ('H'uffman coding), '0' for Bzip1 (deprecated)
             uint8 hundred_k_blocksize;  // '1'..'9' block-size 100 kB-900 kB (uncompressed)
-            char compressed_magic[8];   // 0x314159265359 (BCD (pi))
+
+            // block header (also repeated for every block)
+            char compressed_magic[6];   // 0x314159265359 (BCD (pi))
             uint32 crc;                 // checksum for this block
             uint8 randomised;           // 0=>normal, 1=>randomised (deprecated)
         } bzip2_header_t;

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -2,7 +2,7 @@ import sys
 
 import unblob.plugins
 from unblob import cli
-from unblob.file_utils import File
+from unblob.file_utils import File, iterbits
 from unblob.parser import _HexStringToRegex
 
 _HexStringToRegex.literal
@@ -16,3 +16,5 @@ cli.cli.context_class
 
 unblob.plugins.hookimpl
 File.from_bytes
+
+iterbits


### PR DESCRIPTION
There is a stream header and a block header in bzip2. Stream header includes the gile magic (BZ), the version and the 100k_blocksize.
    
Block header includes the magic, a crc and a randomised bit flag.

Properly separated stream header, footer and block header handling.

Instead of iterating bit by bit which is super slow, we pre-calculate each possible stream end magic bytes (thanks Florian for the inspiration) and try to match on those using hyperscan.

