### PR TITLE
Use hyperscan dot all & fix FAT jump error

### DIFF
--- a/unblob/finder.py
+++ b/unblob/finder.py
@@ -176,7 +176,11 @@ def build_hyperscan_database(handlers: Handlers) -> Tuple[hyperscan.Database, Di
         for pattern in handler.PATTERNS:
             try:
                 patterns.append(
-                    (pattern.as_regex(), pattern_id, hyperscan.HS_FLAG_SOM_LEFTMOST)
+                    (
+                        pattern.as_regex(),
+                        pattern_id,
+                        hyperscan.HS_FLAG_SOM_LEFTMOST | hyperscan.HS_FLAG_DOTALL,
+                    )
                 )
             except InvalidHexString as e:
                 logger.error(

--- a/unblob/handlers/filesystem/fat.py
+++ b/unblob/handlers/filesystem/fat.py
@@ -29,9 +29,7 @@ class FATHandler(StructHandler):
             // 495 (0x1EF) bytes of whatever
             // 55 AA is the "signature". "This will be the end of the sector only in case the
             // sector size is 512."
-            // Hyperscan fails to match with any jump larger then 142 bytes, no idea why so
-            // signature will be checked in calculate_chunk
-            ( EB | E9 ) [13] ( 01 | 02 | 04 | 08 | 10 | 20 | 40 | 80 )
+            ( EB | E9 ) [13] ( 01 | 02 | 04 | 08 | 10 | 20 | 40 | 80 ) [495] 55 AA
         """
         )
     ]
@@ -136,11 +134,6 @@ class FATHandler(StructHandler):
         return True
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
-        signature_start = start_offset + 510
-        signature_end = start_offset + 512
-        if file[signature_start:signature_end] != b"\x55\xaa":
-            raise InvalidInputFormat("Signature mismatch")
-
         header = self.cparser_le.fat12_16_bootsec_t(file)
 
         if header.FileSysType in (b"FAT12   ", b"FAT16   "):


### PR DESCRIPTION
Without DOT_ALL flag '.' match equals to [^\n] as we want to match on newline charaters we should use this flag, which also speeds up operation.

https://intel.github.io/hyperscan/dev-reference/performance.html#dot-all-mode

