### PR TITLE
Extend magic skip list

### DIFF
--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -28,7 +28,17 @@ logger = get_logger()
 
 DEFAULT_DEPTH = 10
 DEFAULT_PROCESS_NUM = multiprocessing.cpu_count()
-DEFAULT_SKIP_MAGIC = ("ELF", "JPEG", "GIF", "PNG")
+DEFAULT_SKIP_MAGIC = (
+    "ELF",
+    "JPEG",
+    "GIF",
+    "PNG",
+    "compiled Java class",
+    "TrueType Font data",
+    "PDF document",
+    "magic binary file",
+    "MS Windows icon resource",
+)
 
 
 @attr.define(kw_only=True)


### PR DESCRIPTION
    Extend the default list of skipped files by their magic type
    
    Certain files are not worth trying to extract further as there is usually
    nothing that can be extracted, but due to their file type could lead to
    many false detection and failed extraction.


close #339 