### PR TITLE
Add binary flat executables (BFLT) to the skip list

### DIFF
--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -29,6 +29,7 @@ logger = get_logger()
 DEFAULT_DEPTH = 10
 DEFAULT_PROCESS_NUM = multiprocessing.cpu_count()
 DEFAULT_SKIP_MAGIC = (
+    "BFLT",
     "ELF",
     "JPEG",
     "GIF",


### PR DESCRIPTION
Add binary flat executables (BFLT) to the skip list given that the executable code can be gzipped.