### PR TITLE
compress: handle decompression errors and too short chunks as error

### DIFF
--- a/tests/handlers/compression/test_compress.py
+++ b/tests/handlers/compression/test_compress.py
@@ -25,9 +25,6 @@ from unblob.handlers.compression.compress import UnixCompressHandler
         pytest.param(
             b"\x1f\x9d\x09\x61\xe0\xc0\x61\x53\x26\x86\x02", 0, 0xB, id="valid_max"
         ),
-        pytest.param(
-            b"\x1f\x9d\x09\x61\xe0\xc0\x61\x53\x26\x86\xff", 0, 0x9, id="invalid_code"
-        ),
     ),
 )
 def test_unlzw(content: bytes, start_offset: int, expected_end_offset: int):
@@ -55,6 +52,9 @@ def test_unlzw(content: bytes, start_offset: int, expected_end_offset: int):
         pytest.param(b"\x1f\x9d\xff", 0, id="header_invalid_flag_code"),
         pytest.param(b"\x1f\x9d\x90\xff\xff", 0, id="code_not_literal"),
         pytest.param(b"\x1f\x9d\x90\x61", 0, id="file_ends_before_stream"),
+        pytest.param(
+            b"\x1f\x9d\x09\x61\xe0\xc0\x61\x53\x26\x86\xff", 0, id="invalid_code"
+        ),
     ),
 )
 def test_unlzw_errors(content: bytes, start_offset: int):


### PR DESCRIPTION
We had a heuristic to recursively try to find the end of a valid compressed
chunk, however it yield to many false-positives. Unfortunately we have no
exact way to detect the end of the chunk as there is no end marker, or size
indication.

We just assume that the compression must be good and in most cases the
compressed content would be the whole file, so there is actually no need to
try to find the end recursively. We can handle extra 0byte padding after
the end, though the decompression would pick those up as well, which would
also result in some extra 0bytes in the decompressed output, but probably
this is the least bad in this scenario.

We also check if the chunk is at least 5 bytes long, as that is a sane minimum
for the header (3) + first data read (2).

closes #348