### PR TITLE
Add a copy_to_file utility function to file_utils.

### DIFF
--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -234,6 +234,12 @@ def iterate_file(
         yield data
 
 
+def copy_to_file(input_file: File, output_path: Path, offset: int, length: int):
+    with output_path.open("wb") as f:
+        for line in iterate_file(input_file, offset, length):
+            f.write(line)
+
+
 class StructParser:
     """Wrapper for dissect.cstruct to handle different endianness parsing dynamically."""
 

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -2,7 +2,7 @@ import sys
 
 import unblob.plugins
 from unblob import cli
-from unblob.file_utils import File, iterbits
+from unblob.file_utils import File, copy_to_file, iterbits
 from unblob.parser import _HexStringToRegex
 
 _HexStringToRegex.literal
@@ -18,3 +18,4 @@ unblob.plugins.hookimpl
 File.from_bytes
 
 iterbits
+copy_to_file


### PR DESCRIPTION
Extractors tend to copy content from the input file into separate
output files by seeking to specific offset and reading a set amount of
bytes. This is a behavior we observed multiple times in our internal
handlers.

Depending on the format and what's packed in it, these lengths can be
quite large and could be a problem in terms of RAM usage.

The 'copy_to_file' function include everything (opening the output file,
seeking to the right offset, reading bytes), while limiting memory usage
by using our iterate_file Iterator that reads 4KB at a time.