### PR TITLE
Fix tar handler

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -61,3 +61,22 @@ def test_with_squized_end():
     binary = unhex(WITH_SQUEEZED_END)
     assert len(binary) == 0x40
     assert binary == b"\xFF" * 0x40
+
+
+WITH_SQUEEZE_AFTER_SQUEEZE = """\
+00000000  20 20 20 20 20 20 20 20  20 20 20 20 20 20 20 20  |                |
+*
+00000040  78 78 78 78 78 78 78 78  78 78 78 78 78 78 78 78  |xxxxxxxxxxxxxxxx|
+*
+00000080  20 20 20 20 20 20 20 20  20 20 20 20 20 20 20 20  |                |
+*
+000000C0
+"""
+
+
+def test_with_squeeze_after_squeeze():
+    binary = unhex(WITH_SQUEEZE_AFTER_SQUEEZE)
+    assert len(binary) == 0xC0
+    assert binary[:0x40] == b" " * 0x40
+    assert binary[0x40:0x80] == b"x" * 0x40
+    assert binary[0x80:] == b" " * 0x40

--- a/unblob/handlers/archive/tar.py
+++ b/unblob/handlers/archive/tar.py
@@ -5,7 +5,7 @@ from structlog import get_logger
 
 from unblob.extractors.command import Command
 
-from ...file_utils import decode_int, round_up, snull
+from ...file_utils import OffsetFile, decode_int, round_up, snull
 from ...models import File, HexString, StructHandler, ValidChunk
 
 logger = get_logger()
@@ -19,16 +19,19 @@ MAGIC_OFFSET = 257
 ZERO_BLOCK = bytes([0]) * BLOCK_SIZE
 
 
-def _get_tar_end_offset(file: File):
+def _get_tar_end_offset(file: File, offset=0):
+    file_with_offset = OffsetFile(file, offset)
+
     # First find the end of the last entry in the file
-    last_offset = _get_end_of_last_tar_entry(file)
+    last_offset = _get_end_of_last_tar_entry(file_with_offset)
     if last_offset == -1:
-        return last_offset
+        return -1
+
     # Then find where the final zero blocks end
-    return _find_end_of_padding(file, find_from=last_offset)
+    return offset + _find_end_of_padding(file_with_offset, find_from=last_offset)
 
 
-def _get_end_of_last_tar_entry(file: File) -> int:
+def _get_end_of_last_tar_entry(file) -> int:
 
     try:
         tf = tarfile.TarFile(mode="r", fileobj=file)
@@ -47,7 +50,7 @@ def _get_end_of_last_tar_entry(file: File) -> int:
     return last_member.offset_data + last_file_size
 
 
-def _find_end_of_padding(file: File, *, find_from: int) -> int:
+def _find_end_of_padding(file, *, find_from: int) -> int:
     find_from = round_up(find_from, BLOCK_SIZE)
     find_to = round_up(find_from + END_OF_ARCHIVE_MARKER_SIZE, tarfile.RECORDSIZE)
 
@@ -104,12 +107,12 @@ class TarHandler(StructHandler):
     )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
+        file.seek(start_offset)
         header = self.parse_header(file)
         header_size = snull(header.size)
         decode_int(header_size, 8)
 
-        file.seek(start_offset)
-        end_offset = _get_tar_end_offset(file)
+        end_offset = _get_tar_end_offset(file, start_offset)
         if end_offset == -1:
             return
         return ValidChunk(start_offset=start_offset, end_offset=end_offset)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -2,7 +2,7 @@ import sys
 
 import unblob.plugins
 from unblob import cli
-from unblob.file_utils import File, iterbits
+from unblob.file_utils import File, iterbits, round_down
 from unblob.parser import _HexStringToRegex
 
 _HexStringToRegex.literal
@@ -18,3 +18,4 @@ unblob.plugins.hookimpl
 File.from_bytes
 
 iterbits
+round_down


### PR DESCRIPTION
There are 2 issues handled in this PR:
- trailing padding blocks are considered not part of the tar chunk
- start offset being ignored/handled in a wrong way during chunk discovery

There was also a bug in `unhex` used for tests, that occurs when using `*` and one hex line, that is also repeated.

resolves #356
