### PR TITLE
 Add SQLite3 files to the skip list

### DIFF
--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -45,6 +45,7 @@ DEFAULT_SKIP_MAGIC = (
     "JPEG",
     "GIF",
     "PNG",
+    "SQLite",
     "compiled Java class",
     "TrueType Font data",
     "PDF document",


### PR DESCRIPTION
The extraction could be improved by skipping SQLite3 database files.